### PR TITLE
[jruby] export more javax.* packages

### DIFF
--- a/osgi-bundles/bundles/jruby/pom.xml
+++ b/osgi-bundles/bundles/jruby/pom.xml
@@ -212,6 +212,8 @@
                             javax.security.auth.*;
                             javax.security.auth.x500;
                             javax.security.auth.x500.*;
+                            javax.transaction;
+                            javax.transaction.xa;
                             <!-- nokogiri -->
                             javax.xml;
                             javax.xml.namespace;

--- a/osgi-bundles/bundles/jruby/pom.xml
+++ b/osgi-bundles/bundles/jruby/pom.xml
@@ -190,6 +190,12 @@
                             javax.management.*;
                             javax.naming;
                             javax.naming.*;
+                            javax.sql;
+                            javax.sql.*;
+                            javax.sql.rowset;
+                            javax.sql.rowset.*;
+                            javax.sql.rowset.serial;
+                            javax.sql.rowset.serial.*;
                             javax.crypto;
                             javax.crypto.*;
                             javax.crypto.spec;

--- a/osgi-bundles/bundles/jruby/pom.xml
+++ b/osgi-bundles/bundles/jruby/pom.xml
@@ -184,6 +184,8 @@
                             sun.security.*;
                             sun.security.util;
                             sun.security.util.*;
+                            javax.annotation;
+                            javax.annotation.*;
                             javax.management;
                             javax.management.*;
                             javax.naming;

--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -187,6 +187,9 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "javax.net.ssl," +
              "javax.crypto," +
              "javax.crypto.spec," +
+             "javax.sql," +
+             "javax.sql.rowset," +
+             "javax.sql.rowset.serial," +
              // XML (sax parser)
              "javax.xml," +
              "javax.xml.namespace," +

--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -179,9 +179,15 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "com.sun.xml.internal.ws.wsdl.writer.document.soap," +
              "com.sun.xml.internal.ws.wsdl.writer.document.soap12," +
              "com.sun.xml.internal.ws.wsdl.writer.document.xsd," +
-             // sax parser
+             // javax packages
+             "javax.annotation," +
+             "javax.management," +
+             "javax.naming," +
              "javax.net," +
              "javax.net.ssl," +
+             "javax.crypto," +
+             "javax.crypto.spec," +
+             // XML (sax parser)
              "javax.xml," +
              "javax.xml.namespace," +
              "javax.xml.parsers," +
@@ -195,7 +201,6 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "javax.xml.transform.stax," +
              "javax.xml.transform.stream," +
              "javax.xml.xpath," +
-             "javax.annotation," +
              "javax.jws.soap," +
              "com.sun.org," +
              "com.sun.org.apache," +
@@ -226,10 +231,6 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "sun.misc.unsafe," +
              "sun.security," +
              "sun.security.util," +
-             "javax.crypto," +
-             "javax.crypto.spec," +
-             "javax.management," +
-             "javax.naming," +
              "javax.servlet;version=3.1," +
              "javax.servlet.http;version=3.1")
     @Description("Java extension/platform Packages to export from the system bundle")

--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -190,6 +190,8 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "javax.sql," +
              "javax.sql.rowset," +
              "javax.sql.rowset.serial," +
+             "javax.transaction," +
+             "javax.transaction.xa," +
              // XML (sax parser)
              "javax.xml," +
              "javax.xml.namespace," +


### PR DESCRIPTION
crucial part is `javax.sql` ... since AR-JDBC will now directly attempt to load `javax.sql.DataSource` :
```
[stripe-plugin] Failure in add_payment_method: java.lang.NoClassDefFoundError: javax/sql/DataSource
  arjdbc.jdbc.RubyJdbcConnection.setDataSourceFactory(RubyJdbcConnection.java:1788)
  arjdbc.jdbc.RubyJdbcConnection.setupConnectionFactory(RubyJdbcConnection.java:1828)
  arjdbc.jdbc.RubyJdbcConnection.doInitialize(RubyJdbcConnection.java:515)
  arjdbc.jdbc.RubyJdbcConnection.initialize(RubyJdbcConnection.java:507)
```