### PR TITLE
Metrics service

### DIFF
--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/glue/PersistentBusProvider.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/glue/PersistentBusProvider.java
@@ -37,7 +37,7 @@ import com.codahale.metrics.MetricRegistry;
 
 public class PersistentBusProvider implements Provider<PersistentBus> {
 
-    private final static Logger logger = LoggerFactory.getLogger(PersistentBusProvider.class);
+    private static final Logger logger = LoggerFactory.getLogger(PersistentBusProvider.class);
 
     private final PersistentBusConfig busConfig;
 

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIKillbillRegistrar.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIKillbillRegistrar.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceRegistration;
 
 public class OSGIKillbillRegistrar {
@@ -34,6 +35,11 @@ public class OSGIKillbillRegistrar {
     }
 
     public <S> void registerService(final BundleContext context, final Class<S> svcClass, final S service, final Dictionary props) {
+        final ServiceRegistration svcRegistration = context.registerService(svcClass.getName(), service, props);
+        serviceRegistrations.put(svcClass.getName(), svcRegistration);
+    }
+
+    public <S> void registerService(final BundleContext context, final Class<S> svcClass, final ServiceFactory<S> service, final Dictionary props) {
         final ServiceRegistration svcRegistration = context.registerService(svcClass.getName(), service, props);
         serviceRegistrations.put(svcClass.getName(), svcRegistration);
     }

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIMetrics.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIMetrics.java
@@ -1,8 +1,21 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.osgi.api;
 
-/**
- * Created by arodrigues on 9/17/15.
- */
 public interface OSGIMetrics {
     void markMeter(String meterName);
 

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIMetrics.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIMetrics.java
@@ -1,0 +1,18 @@
+package org.killbill.billing.osgi.api;
+
+/**
+ * Created by arodrigues on 9/17/15.
+ */
+public interface OSGIMetrics {
+    void markMeter(String meterName);
+
+    void recordHistogramValue(String histogramName, long value);
+
+    void incrementCounter(String counterName);
+
+    void incrementCounter(String counterName, long step);
+
+    void decrementCounter(String counterName);
+
+    void decrementCounter(String counterName, long step);
+}

--- a/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyActivator.java
+++ b/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyActivator.java
@@ -35,7 +35,7 @@ import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillEventDispatcher.OSGI
 import org.osgi.framework.BundleContext;
 import org.osgi.service.log.LogService;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Nomenclature:
@@ -130,7 +130,7 @@ public class JRubyActivator extends KillbillActivatorBase {
         killbillServices.put("root", rubyConfig.getPluginVersionRoot().getAbsolutePath());
         killbillServices.put("logger", logService);
         // Default to the plugin root dir if no jruby plugins specific configuration directory was specified
-        killbillServices.put("conf_dir", Objects.firstNonNull(configProperties.getString(JRUBY_PLUGINS_CONF_DIR), rubyConfig.getPluginVersionRoot().getAbsolutePath()));
+        killbillServices.put("conf_dir", MoreObjects.firstNonNull(configProperties.getString(JRUBY_PLUGINS_CONF_DIR), rubyConfig.getPluginVersionRoot().getAbsolutePath()));
 
         // Start the plugin synchronously
         doStartPlugin(pluginMain, context, killbillServices);
@@ -150,7 +150,7 @@ public class JRubyActivator extends KillbillActivatorBase {
             return;
         }
 
-        final Integer restart_delay_sec = Integer.parseInt((Objects.firstNonNull(configProperties.getString(JRUBY_PLUGINS_RESTART_DELAY_SECS), "5")));
+        final Integer restart_delay_sec = Integer.parseInt((MoreObjects.firstNonNull(configProperties.getString(JRUBY_PLUGINS_RESTART_DELAY_SECS), "5")));
         restartFuture = Executors.newSingleThreadScheduledExecutor("jruby-restarter-" + pluginMain)
                                  .scheduleWithFixedDelay(new Runnable() {
                                      long lastRestartMillis = System.currentTimeMillis();

--- a/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyInvoicePlugin.java
+++ b/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyInvoicePlugin.java
@@ -28,7 +28,6 @@ import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.osgi.api.OSGIPluginProperties;
 import org.killbill.billing.osgi.api.config.PluginRubyConfig;
 import org.killbill.billing.payment.api.PluginProperty;
-import org.killbill.billing.payment.plugin.api.PaymentPluginApiException;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.killbill.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.osgi.framework.BundleContext;

--- a/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyPaymentPlugin.java
+++ b/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyPaymentPlugin.java
@@ -156,7 +156,7 @@ public class JRubyPaymentPlugin extends JRubyNotificationPlugin implements Payme
         callWithRuntimeAndChecking(new PluginCallback<Void, PaymentPluginApiException>() {
             @Override
             public Void doCall(final Ruby runtime) throws PaymentPluginApiException {
-                ((PaymentPluginApi) pluginInstance).addPaymentMethod(kbAccountId, kbPaymentMethodId, paymentMethodProps, Boolean.valueOf(setDefault), properties, context);
+                ((PaymentPluginApi) pluginInstance).addPaymentMethod(kbAccountId, kbPaymentMethodId, paymentMethodProps, setDefault, properties, context);
                 return null;
             }
         });
@@ -199,7 +199,7 @@ public class JRubyPaymentPlugin extends JRubyNotificationPlugin implements Payme
         return callWithRuntimeAndChecking(new PluginCallback<List<PaymentMethodInfoPlugin>, PaymentPluginApiException>() {
             @Override
             public List<PaymentMethodInfoPlugin> doCall(final Ruby runtime) throws PaymentPluginApiException {
-                return ((PaymentPluginApi) pluginInstance).getPaymentMethods(kbAccountId, Boolean.valueOf(refreshFromGateway), properties, context);
+                return ((PaymentPluginApi) pluginInstance).getPaymentMethods(kbAccountId, refreshFromGateway, properties, context);
             }
         });
     }

--- a/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyPlugin.java
+++ b/osgi-bundles/bundles/jruby/src/main/java/org/killbill/billing/osgi/bundles/jruby/JRubyPlugin.java
@@ -33,7 +33,6 @@ import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.embed.ScriptingContainer;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.killbill.billing.osgi.api.config.PluginRubyConfig;
-import org.killbill.billing.payment.plugin.api.PaymentPluginApiException;
 import org.killbill.killbill.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/KillbillActivatorBase.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/KillbillActivatorBase.java
@@ -31,6 +31,7 @@ public abstract class KillbillActivatorBase implements BundleActivator {
     protected OSGIKillbillDataSource dataSource;
     protected OSGIKillbillEventDispatcher dispatcher;
     protected OSGIConfigPropertiesService configProperties;
+    protected OSGIKillbillMetrics killbillMetrics;
 
     @Override
     public void start(final BundleContext context) throws Exception {
@@ -40,6 +41,7 @@ public abstract class KillbillActivatorBase implements BundleActivator {
         dataSource = new OSGIKillbillDataSource(context);
         dispatcher = new OSGIKillbillEventDispatcher(context);
         configProperties = new OSGIConfigPropertiesService(context);
+        killbillMetrics = new OSGIKillbillMetrics(context);
 
         // Registrar for bundle
         registrar = new OSGIKillbillRegistrar();
@@ -69,6 +71,10 @@ public abstract class KillbillActivatorBase implements BundleActivator {
         if (logService != null) {
             logService.close();
             logService = null;
+        }
+        if (killbillMetrics != null) {
+            killbillMetrics.close();
+            killbillMetrics = null;
         }
 
         try {

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/OSGIKillbillMetrics.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/OSGIKillbillMetrics.java
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.killbill.osgi.libs.killbill;
 
 import org.killbill.billing.osgi.api.OSGIMetrics;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
 
-/**
- * Created by arodrigues on 9/17/15.
- */
 public class OSGIKillbillMetrics extends OSGIKillbillLibraryBase implements OSGIMetrics {
 
     private final ServiceTracker killbillTracker;

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/OSGIKillbillMetrics.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/killbill/osgi/libs/killbill/OSGIKillbillMetrics.java
@@ -1,0 +1,92 @@
+package org.killbill.killbill.osgi.libs.killbill;
+
+import org.killbill.billing.osgi.api.OSGIMetrics;
+import org.osgi.framework.BundleContext;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * Created by arodrigues on 9/17/15.
+ */
+public class OSGIKillbillMetrics extends OSGIKillbillLibraryBase implements OSGIMetrics {
+
+    private final ServiceTracker killbillTracker;
+
+    public OSGIKillbillMetrics(final BundleContext context) {
+        killbillTracker = new ServiceTracker(context, OSGIMetrics.class.getName(), null);
+        killbillTracker.open();
+    }
+
+    @Override
+    public void close() {
+        if (killbillTracker != null) {
+            killbillTracker.close();
+        }
+    }
+
+    @Override
+    public void markMeter(final String meterName) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.markMeter(meterName);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void recordHistogramValue(final String histogramName, final long value) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.recordHistogramValue(histogramName, value);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void incrementCounter(final String counterName) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.incrementCounter(counterName);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void incrementCounter(final String counterName, final long step) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.incrementCounter(counterName, step);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void decrementCounter(final String counterName) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.decrementCounter(counterName);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public void decrementCounter(final String counterName, final long step) {
+        withServiceTracker(killbillTracker, new APICallback<Void, OSGIMetrics>(OSGIMetrics.class.getName()) {
+            @Override
+            public Void executeWithService(final OSGIMetrics service) {
+                service.decrementCounter(counterName, step);
+                return null;
+            }
+        });
+    }
+}
+

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIMetrics.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.osgi;
 
 import com.codahale.metrics.Counter;
@@ -6,9 +22,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import org.killbill.billing.osgi.api.OSGIMetrics;
 
-/**
- * Created by arodrigues on 9/17/15.
- */
 public class DefaultOSGIMetrics implements OSGIMetrics {
     private final MetricRegistry registry;
     private final String pluginName;

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIMetrics.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIMetrics.java
@@ -1,0 +1,58 @@
+package org.killbill.billing.osgi;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import org.killbill.billing.osgi.api.OSGIMetrics;
+
+/**
+ * Created by arodrigues on 9/17/15.
+ */
+public class DefaultOSGIMetrics implements OSGIMetrics {
+    private final MetricRegistry registry;
+    private final String pluginName;
+
+    public DefaultOSGIMetrics(final MetricRegistry registry, final String pluginName) {
+        this.registry = registry;
+        this.pluginName = pluginName;
+    }
+
+    @Override
+    public void markMeter(final String meterName) {
+        final Meter meter = registry.meter(fullMetricName(meterName));
+        meter.mark();
+    }
+
+    @Override
+    public void recordHistogramValue(final String histogramName, final long value) {
+        final Histogram histogram = registry.histogram(fullMetricName(histogramName));
+        histogram.update(value);
+    }
+
+    @Override
+    public void incrementCounter(final String counterName) {
+        incrementCounter(counterName, 1);
+    }
+
+    @Override
+    public void incrementCounter(final String counterName, final long step) {
+        final Counter counter = registry.counter(fullMetricName(counterName));
+        counter.inc(step);
+    }
+
+    @Override
+    public void decrementCounter(final String counterName) {
+        decrementCounter(counterName, 1);
+    }
+
+    @Override
+    public void decrementCounter(final String counterName, final long step) {
+        final Counter counter = registry.counter(fullMetricName(counterName));
+        counter.dec(step);
+    }
+
+    private String fullMetricName(final String metricName) {
+        return pluginName + "." + metricName;
+    }
+}

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -109,7 +109,7 @@ public class DefaultOSGIService implements OSGIService {
     }
 
     private Framework createAndInitFramework() throws BundleException {
-        final StringBuffer systemExtraPackages = new StringBuffer(osgiConfig.getSystemBundleExportPackagesApi());
+        final StringBuilder systemExtraPackages = new StringBuilder(osgiConfig.getSystemBundleExportPackagesApi());
         if (!osgiConfig.getSystemBundleExportPackagesJava().isEmpty()) {
             systemExtraPackages
                     .append(",")

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIMetricsFactory.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIMetricsFactory.java
@@ -1,0 +1,32 @@
+package org.killbill.billing.osgi;
+
+import com.codahale.metrics.MetricRegistry;
+import org.killbill.billing.osgi.api.OSGIMetrics;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceRegistration;
+
+import javax.inject.Inject;
+
+/**
+ * Created by arodrigues on 9/17/15.
+ */
+public class OSGIMetricsFactory implements ServiceFactory<OSGIMetrics> {
+
+    private final MetricRegistry metricRegistry;
+
+    @Inject
+    public OSGIMetricsFactory(final MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public OSGIMetrics getService(final Bundle bundle, final ServiceRegistration<OSGIMetrics> registration) {
+        return new DefaultOSGIMetrics(metricRegistry, bundle.getSymbolicName());
+    }
+
+    @Override
+    public void ungetService(final Bundle bundle, final ServiceRegistration<OSGIMetrics> registration, final OSGIMetrics service) {
+
+    }
+}

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIMetricsFactory.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIMetricsFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.osgi;
 
 import com.codahale.metrics.MetricRegistry;
@@ -8,9 +24,6 @@ import org.osgi.framework.ServiceRegistration;
 
 import javax.inject.Inject;
 
-/**
- * Created by arodrigues on 9/17/15.
- */
 public class OSGIMetricsFactory implements ServiceFactory<OSGIMetrics> {
 
     private final MetricRegistry metricRegistry;

--- a/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
@@ -26,6 +26,7 @@ import org.killbill.billing.osgi.DefaultOSGIKillbill;
 import org.killbill.billing.osgi.DefaultOSGIService;
 import org.killbill.billing.osgi.KillbillActivator;
 import org.killbill.billing.osgi.KillbillEventObservable;
+import org.killbill.billing.osgi.OSGIMetricsFactory;
 import org.killbill.billing.osgi.PureOSGIBundleFinder;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
 import org.killbill.billing.osgi.api.OSGIKillbill;
@@ -92,6 +93,8 @@ public class DefaultOSGIModule extends KillBillPlatformModuleBase {
         installOSGIServlet();
         installHttpService();
         installDataSource();
+
+        bind(OSGIMetricsFactory.class);
 
         bind(OSGIService.class).to(DefaultOSGIService.class).asEagerSingleton();
 

--- a/platform-api/src/main/java/org/killbill/billing/platform/api/KillbillPlatformConfig.java
+++ b/platform-api/src/main/java/org/killbill/billing/platform/api/KillbillPlatformConfig.java
@@ -19,5 +19,5 @@ package org.killbill.billing.platform.api;
 
 public interface KillbillPlatformConfig {
 
-    final static String KILL_BILL_NAMESPACE = "org.killbill.";
+    String KILL_BILL_NAMESPACE = "org.killbill.";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.44-SNAPSHOT</version>
+        <version>0.45-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.9-SNAPSHOT</version>

--- a/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
@@ -34,8 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
-import com.google.common.io.InputSupplier;
 import com.google.common.io.Resources;
 import com.google.inject.Provider;
 

--- a/server/src/main/java/org/killbill/billing/server/updatechecker/ClientInfo.java
+++ b/server/src/main/java/org/killbill/billing/server/updatechecker/ClientInfo.java
@@ -24,7 +24,7 @@ import javax.servlet.ServletContext;
 
 import org.skife.config.ConfigSource;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.base.Strings;
 
@@ -154,7 +154,7 @@ public class ClientInfo {
     }
 
     private String getProperty(final StandardSystemProperty standardKey) {
-        return getSanitizedString(Objects.firstNonNull(props.getString(standardKey.key()), UNKNOWN));
+        return getSanitizedString(MoreObjects.firstNonNull(props.getString(standardKey.key()), UNKNOWN));
     }
 
     private String getSanitizedString(final String string) {

--- a/server/src/main/java/org/killbill/billing/server/updatechecker/ProductInfo.java
+++ b/server/src/main/java/org/killbill/billing/server/updatechecker/ProductInfo.java
@@ -20,16 +20,13 @@ package org.killbill.billing.server.updatechecker;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
-import com.google.common.io.InputSupplier;
 import com.google.common.io.Resources;
 
 /**


### PR DESCRIPTION
Initial proposal for the Metrics service, exposing basic metric generation capabilities.

Here's a summary of what's included in this PR (see individual commits for more info):
- Basic clean up (unused imports, deprecated classes, etc) 2930d33
- Service factories registration through `OSGIKillbillRegistrar` d223baf
- Interface and basic implementation of Metrics Service, along with service factory and guice/OSGI code for service wiring (`MetricsRegistry`) and OSGI publishing. df8622e
- OSGIMetrics `ServiceTracker` based implementation, with code to expose service to plugins 0075d3e

The current naming and location of the service classes and interfaces is just a suggestion, totally open for debate.

Regarding classes visibility, I was able to verify that, the way it is now, only the `OSGIMetrics` interface and the `OSGIKillbillMetrics` Service tracker implementation class are visible to plugin, which I think is the desired "behavior". 
