### PR TITLE
Improves the metric generation for registered OSGI services

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
@@ -204,7 +204,7 @@ public class KillbillActivator implements BundleActivator, ServiceListener {
         final OSGIServiceDescriptor desc = new DefaultOSGIServiceDescriptor(serviceReference.getBundle().getSymbolicName(), serviceName);
         switch (eventType) {
             case ServiceEvent.REGISTERED:
-                final T wrappedService = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(theService, serviceName, metricsRegistry);
+                final T wrappedService = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(theService, registration.getServiceType(), serviceName, metricsRegistry);
                 registration.registerService(desc, wrappedService);
                 break;
             case ServiceEvent.UNREGISTERING:

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
@@ -76,7 +76,6 @@ public class KillbillActivator implements BundleActivator, ServiceListener {
     private final OSGIConfigProperties configProperties;
     private final JNDIManager jndiManager;
     private final MetricRegistry metricsRegistry;
-    private final Map<String, Histogram> perPluginCallMetrics;
 
     private final List<OSGIServiceRegistration> allRegistrationHandlers;
 
@@ -99,7 +98,6 @@ public class KillbillActivator implements BundleActivator, ServiceListener {
         this.metricsRegistry = metricsRegistry;
         this.registrar = new OSGIKillbillRegistrar();
         this.allRegistrationHandlers = new LinkedList<OSGIServiceRegistration>();
-        this.perPluginCallMetrics = new HashMap<String, Histogram>();
     }
 
     @Inject(optional = true)
@@ -206,7 +204,7 @@ public class KillbillActivator implements BundleActivator, ServiceListener {
         final OSGIServiceDescriptor desc = new DefaultOSGIServiceDescriptor(serviceReference.getBundle().getSymbolicName(), serviceName);
         switch (eventType) {
             case ServiceEvent.REGISTERED:
-                final T wrappedService = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(theService, metricsRegistry, perPluginCallMetrics);
+                final T wrappedService = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(theService, serviceName, metricsRegistry);
                 registration.registerService(desc, wrappedService);
                 break;
             case ServiceEvent.UNREGISTERING:

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
@@ -40,13 +40,11 @@ import com.codahale.metrics.MetricRegistry;
 public class DefaultHttpService implements HttpService {
 
     private final DefaultServletRouter servletRouter;
-    private final Map<String, Histogram> perPluginCallMetrics;
     private final MetricRegistry metricsRegistry;
 
     @Inject
     public DefaultHttpService(final DefaultServletRouter servletRouter, final MetricRegistry metricsRegistry) {
         this.servletRouter = servletRouter;
-        this.perPluginCallMetrics = new HashMap<String, Histogram>();
         this.metricsRegistry = metricsRegistry;
     }
 
@@ -58,7 +56,7 @@ public class DefaultHttpService implements HttpService {
         } else if (servlet == null) {
             throw new IllegalArgumentException("Invalid servlet (null)");
         }
-        final Servlet wrappedServlet = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(servlet, metricsRegistry, perPluginCallMetrics);
+        final Servlet wrappedServlet = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(servlet, alias, metricsRegistry);
 
         servletRouter.registerServiceFromPath(alias, wrappedServlet);
     }

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
@@ -56,7 +56,7 @@ public class DefaultHttpService implements HttpService {
         } else if (servlet == null) {
             throw new IllegalArgumentException("Invalid servlet (null)");
         }
-        final Servlet wrappedServlet = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(servlet, alias, metricsRegistry);
+        final Servlet wrappedServlet = ContextClassLoaderHelper.getWrappedServiceWithCorrectContextClassLoader(servlet, Servlet.class, alias, metricsRegistry);
 
         servletRouter.registerServiceFromPath(alias, wrappedServlet);
     }


### PR DESCRIPTION
- Improve metric naming, ex: killbill-service.(kb_plugin_latency|kb_plugin_errors).$plugin_name.$method
- Improve latency measurement, by using the Timer metric (latency + rates)
- Add error counter metric, for counting exceptions thrown by a plugin/service