### PR TITLE
Change locker type for PostgreSQL

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -261,6 +261,11 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-postgresql</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-jdbi</artifactId>
         </dependency>
         <dependency>

--- a/server/src/main/java/org/killbill/billing/server/dao/EmbeddedDBFactory.java
+++ b/server/src/main/java/org/killbill/billing/server/dao/EmbeddedDBFactory.java
@@ -24,6 +24,7 @@ import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.killbill.commons.embeddeddb.GenericStandaloneDB;
 import org.killbill.commons.embeddeddb.h2.H2EmbeddedDB;
 import org.killbill.commons.embeddeddb.mysql.MySQLStandaloneDB;
+import org.killbill.commons.embeddeddb.postgresql.PostgreSQLStandaloneDB;
 import org.killbill.commons.jdbi.guice.DaoConfig;
 
 // TODO Rename - not always "embedded"
@@ -52,6 +53,8 @@ public class EmbeddedDBFactory {
             return new MySQLStandaloneDB(databaseName, config.getUsername(), config.getPassword(), config.getJdbcUrl());
         } else if ("h2".equals(uri.getScheme()) && ("mem".equals(schemeLocation) || "file".equals(schemeLocation))) {
             return new H2EmbeddedDB(databaseName, config.getUsername(), config.getPassword(), config.getJdbcUrl());
+        } else if ("postgresql".equals(uri.getScheme())) {
+            return new PostgreSQLStandaloneDB(databaseName, config.getUsername(), config.getPassword(), config.getJdbcUrl());
         } else {
             return new GenericStandaloneDB(databaseName, config.getUsername(), config.getPassword(), config.getJdbcUrl());
         }


### PR DESCRIPTION
When using PostgreSQL, Kill Bill instantiates a MemoryGlobalLocker instead of the PostgreSQLGlobalLocker.

The type of locker to use is chosen by [GlobalLockerModule](https://github.com/killbill/killbill/blob/master/util/src/main/java/org/killbill/billing/util/glue/GlobalLockerModule.java).  The branch for PostgreSQL is not executing because getDBEngine() returns GENERIC.  This pull updates EmbeddedDBFactory to return a PostgreSQLStandaloneDB instance so that GlobalLockerModule will see getDBEngine() as POSTGRESQL and thus create a PostgreSQLGlobalLocker.