### PR TITLE
Issue #630 - use UUID for KillBill session id

### DIFF
--- a/server/src/main/resources/org/killbill/billing/server/ddl.sql
+++ b/server/src/main/resources/org/killbill/billing/server/ddl.sql
@@ -119,6 +119,7 @@ CREATE TABLE bus_ext_events_history (
 drop table if exists sessions;
 create table sessions (
   record_id serial unique
+, id varchar(36) NOT NULL
 , start_timestamp datetime not null
 , last_access_time datetime default null
 , timeout int
@@ -126,3 +127,4 @@ create table sessions (
 , session_data mediumblob default null
 , primary key(record_id)
 ) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
+CREATE UNIQUE INDEX sessions_id ON sessions(id);


### PR DESCRIPTION
Issue [#630](https://github.com/killbill/killbill/issues/630) - use UUID for KillBill session id to improve security.  See pull request [#655](https://github.com/killbill/killbill/pull/655).