### PR TITLE
Issue #652 - storage_engine is deprecated in mysql 5.7.5+

### DIFF
--- a/osgi-bundles/tests/beatrix/src/main/resources/ddl_test.sql
+++ b/osgi-bundles/tests/beatrix/src/main/resources/ddl_test.sql
@@ -1,4 +1,4 @@
-/*! SET storage_engine=INNODB */;
+/*! SET default_storage_engine=INNODB */;
 
 DROP TABLE IF EXISTS test_bundle;
 CREATE TABLE test_bundle (

--- a/osgi-bundles/tests/payment/src/main/resources/ddl_test.sql
+++ b/osgi-bundles/tests/payment/src/main/resources/ddl_test.sql
@@ -1,4 +1,4 @@
-/*! SET storage_engine=INNODB */;
+/*! SET default_storage_engine=INNODB */;
 
 DROP TABLE IF EXISTS test_bundle;
 CREATE TABLE test_bundle (

--- a/platform-test/src/main/resources/org/killbill/billing/beatrix/ddl.sql
+++ b/platform-test/src/main/resources/org/killbill/billing/beatrix/ddl.sql
@@ -1,4 +1,4 @@
-/*! SET storage_engine=INNODB */;
+/*! SET default_storage_engine=INNODB */;
 
 DROP TABLE IF EXISTS notifications;
 CREATE TABLE notifications (

--- a/server/src/main/resources/org/killbill/billing/server/ddl.sql
+++ b/server/src/main/resources/org/killbill/billing/server/ddl.sql
@@ -1,4 +1,4 @@
-/*! SET storage_engine=INNODB */;
+/*! SET default_storage_engine=INNODB */;
 
 DROP TABLE IF EXISTS notifications;
 CREATE TABLE notifications (


### PR DESCRIPTION
Issue [#652](https://github.com/killbill/killbill/issues/652) - storage_engine is deprecated in mysql 5.7.5+, replacing with default_storage_engine.  See also [#658](https://github.com/killbill/killbill/pull/658).