### PR TITLE
Support unpooled database connections

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -61,6 +61,10 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/base/src/main/java/org/killbill/billing/platform/glue/ReferenceableDataSourceSpyProvider.java
+++ b/base/src/main/java/org/killbill/billing/platform/glue/ReferenceableDataSourceSpyProvider.java
@@ -20,13 +20,14 @@ package org.killbill.billing.platform.glue;
 import javax.sql.DataSource;
 
 import org.killbill.billing.platform.jndi.ReferenceableDataSourceSpy;
+import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.killbill.commons.jdbi.guice.DaoConfig;
 import org.killbill.commons.jdbi.guice.DataSourceProvider;
 
 public class ReferenceableDataSourceSpyProvider extends DataSourceProvider {
 
-    public ReferenceableDataSourceSpyProvider(final DaoConfig config, final String poolName) {
-        super(config, poolName);
+    public ReferenceableDataSourceSpyProvider(final DaoConfig config, EmbeddedDB embeddedDB, final String poolName) {
+        super(config, embeddedDB, poolName);
     }
 
     @Override

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -144,6 +144,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-embeddeddb-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/platform-test/src/main/java/org/killbill/billing/platform/test/glue/TestPlatformModule.java
+++ b/platform-test/src/main/java/org/killbill/billing/platform/test/glue/TestPlatformModule.java
@@ -27,14 +27,18 @@ import org.killbill.billing.lifecycle.glue.BusModule;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
 import org.killbill.billing.osgi.api.PluginInfo;
 import org.killbill.billing.osgi.glue.DefaultOSGIModule;
+import org.killbill.billing.osgi.glue.OSGIDataSourceConfig;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.platform.api.KillbillService;
 import org.killbill.billing.platform.glue.KillBillPlatformModuleBase;
 import org.killbill.billing.platform.glue.NotificationQueueModule;
 import org.killbill.billing.platform.jndi.JNDIManager;
+import org.killbill.billing.platform.test.PlatformDBTestingHelper;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 import org.killbill.billing.util.nodes.NodeCommand;
 import org.killbill.billing.util.nodes.NodeInfo;
+import org.killbill.commons.embeddeddb.EmbeddedDB;
+import org.skife.config.ConfigurationObjectFactory;
 
 public abstract class TestPlatformModule extends KillBillPlatformModuleBase {
 
@@ -93,7 +97,10 @@ public abstract class TestPlatformModule extends KillBillPlatformModuleBase {
     }
 
     protected void configureOSGI() {
-        install(new DefaultOSGIModule(configSource, osgiConfigProperties));
+        final OSGIDataSourceConfig osgiDataSourceConfig = new ConfigurationObjectFactory(skifeConfigSource).build(OSGIDataSourceConfig.class);
+        final PlatformDBTestingHelper platformDBTestingHelper = PlatformDBTestingHelper.get();
+        final EmbeddedDB instance = platformDBTestingHelper.getInstance();
+        install(new DefaultOSGIModule(configSource, osgiConfigProperties, osgiDataSourceConfig, instance));
     }
 
     protected void configureJNDI() {


### PR DESCRIPTION
Currently, Kill Bill supports the use of either [c3p0](http://www.mchange.com/projects/c3p0/) or [HikariCP](https://brettwooldridge.github.io/HikariCP/) for pooling database connections. In either case, database connections are managed by software running in the same JVM that Kill Bill is running in.

It would be nice to have the option of configuring Kill Bill so that it doesn't try to pool database connections. This would make it easier to use external database connection pools like [PGBouncer](http://pgbouncer.github.io/).

See also [killbill-commons pull request 19](https://github.com/killbill/killbill-commons/pull/19).