### PR TITLE
server: introduce org.killbill.server.region to specify deployment region (e.g. colo)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.36.11
+    Multi-regions support
+
 0.36.10
     Shutdown sequence enhancements
     Enhance healthcheck support for LB

--- a/server/src/main/java/org/killbill/billing/server/config/KillbillServerConfig.java
+++ b/server/src/main/java/org/killbill/billing/server/config/KillbillServerConfig.java
@@ -41,6 +41,11 @@ public interface KillbillServerConfig extends KillbillPlatformConfig {
     @Description("Server base url")
     public String getBaseUrl();
 
+    @Config(KILL_BILL_NAMESPACE + "server.region")
+    @Default("local")
+    @Description("Region or data center where the server is deployed")
+    public String getRegion();
+
     @Config(KILL_BILL_NAMESPACE + "server.http.gzip")
     @Default("false")
     @Description("Allow Kill Bill to return gzip json when Content-Encoding is set with gzip")


### PR DESCRIPTION
This is only used by the plugins today (e.g. Adyen).

/cc @andrenpaes for review.