### PR TITLE
Export the org.killbill.billing.security package

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -84,6 +84,7 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              "org.killbill.billing.catalog.plugin.api," +
              "org.killbill.billing.entitlement.plugin.api," +
              "org.killbill.billing.currency.api," +
+             "org.killbill.billing.security," +
              "org.killbill.billing.security.api," +
              "org.killbill.billing.overdue.api," +
              "org.killbill.billing.osgi.libs.killbill," +


### PR DESCRIPTION
Add this export from the OSGi system bundle, so plugins are allowed to use objects like org.killbill.billing.security.Permission.