### PR TITLE
server: add InfluxDB integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.140.35</version>
+        <version>0.140.43</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.36.12-SNAPSHOT</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -81,6 +81,61 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.izettle</groupId>
+            <artifactId>dropwizard-metrics-influxdb</artifactId>
+            <!-- We're not quite yet ready to upgrade these... -->
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-datatype-joda</artifactId>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-datatype-guava</artifactId>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-module-afterburner</artifactId>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-annotations</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-io</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-server</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-http</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-util</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.palominolabs.metrics</groupId>
             <artifactId>metrics-guice</artifactId>
             <scope>runtime</scope>

--- a/server/src/main/java/org/killbill/billing/server/config/MetricsInfluxDbConfig.java
+++ b/server/src/main/java/org/killbill/billing/server/config/MetricsInfluxDbConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.config;
+
+import org.killbill.billing.platform.api.KillbillPlatformConfig;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import org.skife.config.Description;
+
+public interface MetricsInfluxDbConfig extends KillbillPlatformConfig {
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb")
+    @Default("false")
+    @Description("Whether metrics reporting to InfluxDB is enabled")
+    public boolean isInfluxDbReportingEnabled();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.host")
+    @Default("localhost")
+    @Description("InfluxDb Hostname")
+    public String getHostname();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.port")
+    @Default("2003")
+    @Description("InfluxDb Port")
+    public int getPort();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.socketTimeout")
+    @Default("1000")
+    @Description("InfluxDb socket timeout")
+    public int getSocketTimeout();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.database")
+    @Default("killbill")
+    @Description("InfluxDb database")
+    public String getDatabase();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.prefix")
+    @Default("killbill")
+    @Description("Prefix all metric names with the given string")
+    public String getPrefix();
+
+    @Config(KILL_BILL_NAMESPACE + "metrics.influxDb.interval")
+    @Default("30")
+    @Description("Reporter polling interval in seconds")
+    public int getInterval();
+}


### PR DESCRIPTION
Tested with the latest [Metrics stack](https://github.com/killbill/killbill-cloud/blob/master/docker/compose/docker-compose.gi.yml), i.e. Kill Bill -> Telegraf (InfluxDB protocol over TCP) -> InfluxDB (InfluxDB protocol over HTTP):

```
org.killbill.metrics.influxDb=true
org.killbill.metrics.influxDb.host=192.168.99.101
org.killbill.metrics.influxDb.port=8094
org.killbill.metrics.influxDb.interval=5
```