### PR TITLE
osgi: add new config property org.killbill.billing.osgi.dao.initializationFailFast

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/glue/OSGIDataSourceConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/glue/OSGIDataSourceConfig.java
@@ -132,4 +132,10 @@ public interface OSGIDataSourceConfig extends DaoConfig {
     @Config(DATA_SOURCE_PROP_PREFIX + "poolingType")
     @Default("HIKARICP")
     DataSourceConnectionPoolingType getConnectionPoolingType();
+
+    @Override
+    @Description("Whether or not initialization should fail on error immediately")
+    @Config(DATA_SOURCE_PROP_PREFIX + "initializationFailFast")
+    @Default("false")
+    boolean isInitializationFailFast();
 }


### PR DESCRIPTION
This needs a new version of the base pom pointing to the latest commons before merging.

See https://github.com/killbill/killbill-commons/pull/26.