### PR TITLE
osgi-bundles: introduce ROOSGIKillbillAPI

### DIFF
--- a/osgi-api/pom.xml
+++ b/osgi-api/pom.xml
@@ -29,6 +29,10 @@
     <name>killbill-platform-osgi-api</name>
     <dependencies>
         <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.kill-bill.billing.plugin</groupId>
             <artifactId>killbill-plugin-api-payment</artifactId>
             <scope>test</scope>

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/ROOSGIKillbillInterceptor.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/ROOSGIKillbillInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+public class ROOSGIKillbillInterceptor<T> implements InvocationHandler {
+
+    private final T t;
+
+    public ROOSGIKillbillInterceptor(final T t) {
+        this.t = t;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getProxy(final T t, final Class<? super T> interfaceType) {
+        final InvocationHandler handler = new ROOSGIKillbillInterceptor(t);
+        return (T) Proxy.newProxyInstance(interfaceType.getClassLoader(),
+                                          new Class<?>[]{interfaceType},
+                                          handler);
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+        final Object[] newArgs = args.length > 0 ? new Object[args.length] : args;
+        for (int i = 0; i < args.length; i++) {
+            final Object argument = args[i];
+            if (argument instanceof TenantContext && !(argument instanceof CallContext)) {
+                newArgs[i] = new ROTenantContext((TenantContext) argument);
+            } else {
+                newArgs[i] = argument;
+            }
+        }
+
+        try {
+            return method.invoke(t, newArgs);
+        } catch (final InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/ROTenantContext.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/ROTenantContext.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api;
+
+import java.util.UUID;
+
+import org.killbill.billing.util.callcontext.TenantContext;
+
+public class ROTenantContext implements TenantContext {
+
+    private final TenantContext delegate;
+
+    public ROTenantContext(final TenantContext delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public UUID getAccountId() {
+        return delegate.getAccountId();
+    }
+
+    @Override
+    public UUID getTenantId() {
+        return delegate.getTenantId();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ROTenantContext that = (ROTenantContext) o;
+
+        return delegate != null ? delegate.equals(that.delegate) : that.delegate == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate != null ? delegate.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ROTenantContext{");
+        sb.append("delegate=").append(delegate);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillActivatorBase.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillActivatorBase.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016 Groupon, Inc
- * Copyright 2016 The Billing Project, LLC
+ * Copyright 2016-2018 Groupon, Inc
+ * Copyright 2016-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -44,6 +44,7 @@ public abstract class KillbillActivatorBase implements BundleActivator {
     public static final String DISABLED_FILE_NAME = "disabled.txt";
 
     protected OSGIKillbillAPI killbillAPI;
+    protected ROOSGIKillbillAPI roOSGIkillbillAPI;
     protected OSGIKillbillLogService logService;
     protected OSGIKillbillRegistrar registrar;
     protected OSGIKillbillDataSource dataSource;
@@ -63,6 +64,7 @@ public abstract class KillbillActivatorBase implements BundleActivator {
         logSafely(LogService.LOG_INFO, String.format("OSGI bundle='%s' received START command", context.getBundle().getSymbolicName()));
 
         killbillAPI = new OSGIKillbillAPI(context);
+        roOSGIkillbillAPI = new ROOSGIKillbillAPI(context);
         configureSLF4JBinding();
         dataSource = new OSGIKillbillDataSource(context);
         dispatcher = new OSGIKillbillEventDispatcher(context);
@@ -116,6 +118,10 @@ public abstract class KillbillActivatorBase implements BundleActivator {
         if (killbillAPI != null) {
             killbillAPI.close();
             killbillAPI = null;
+        }
+        if (roOSGIkillbillAPI != null) {
+            roOSGIkillbillAPI.close();
+            roOSGIkillbillAPI = null;
         }
         if (dataSource != null) {
             dataSource.close();

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/ROOSGIKillbillAPI.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/ROOSGIKillbillAPI.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.libs.killbill;
+
+import org.killbill.billing.account.api.AccountUserApi;
+import org.killbill.billing.catalog.api.CatalogUserApi;
+import org.killbill.billing.currency.api.CurrencyConversionApi;
+import org.killbill.billing.entitlement.api.EntitlementApi;
+import org.killbill.billing.entitlement.api.SubscriptionApi;
+import org.killbill.billing.invoice.api.InvoicePaymentApi;
+import org.killbill.billing.invoice.api.InvoiceUserApi;
+import org.killbill.billing.osgi.api.PluginsInfoApi;
+import org.killbill.billing.osgi.api.ROOSGIKillbillInterceptor;
+import org.killbill.billing.osgi.api.config.PluginConfigServiceApi;
+import org.killbill.billing.overdue.api.OverdueApi;
+import org.killbill.billing.payment.api.AdminPaymentApi;
+import org.killbill.billing.payment.api.PaymentApi;
+import org.killbill.billing.security.api.SecurityApi;
+import org.killbill.billing.tenant.api.TenantUserApi;
+import org.killbill.billing.usage.api.UsageUserApi;
+import org.killbill.billing.util.api.AuditUserApi;
+import org.killbill.billing.util.api.CustomFieldUserApi;
+import org.killbill.billing.util.api.ExportUserApi;
+import org.killbill.billing.util.api.RecordIdApi;
+import org.killbill.billing.util.api.TagUserApi;
+import org.killbill.billing.util.nodes.KillbillNodesApi;
+import org.osgi.framework.BundleContext;
+
+public class ROOSGIKillbillAPI extends OSGIKillbillAPI {
+
+    public ROOSGIKillbillAPI(final BundleContext context) {
+        super(context);
+    }
+
+    @Override
+    public AccountUserApi getAccountUserApi() {
+        return ROOSGIKillbillInterceptor.<AccountUserApi>getProxy(super.getAccountUserApi(), AccountUserApi.class);
+    }
+
+    @Override
+    public CatalogUserApi getCatalogUserApi() {
+        return ROOSGIKillbillInterceptor.<CatalogUserApi>getProxy(super.getCatalogUserApi(), CatalogUserApi.class);
+    }
+
+    @Override
+    public SubscriptionApi getSubscriptionApi() {
+        return ROOSGIKillbillInterceptor.<SubscriptionApi>getProxy(super.getSubscriptionApi(), SubscriptionApi.class);
+    }
+
+    @Override
+    public InvoicePaymentApi getInvoicePaymentApi() {
+        return ROOSGIKillbillInterceptor.<InvoicePaymentApi>getProxy(super.getInvoicePaymentApi(), InvoicePaymentApi.class);
+    }
+
+    @Override
+    public InvoiceUserApi getInvoiceUserApi() {
+        return ROOSGIKillbillInterceptor.<InvoiceUserApi>getProxy(super.getInvoiceUserApi(), InvoiceUserApi.class);
+    }
+
+    @Override
+    public PaymentApi getPaymentApi() {
+        return ROOSGIKillbillInterceptor.<PaymentApi>getProxy(super.getPaymentApi(), PaymentApi.class);
+    }
+
+    @Override
+    public TenantUserApi getTenantUserApi() {
+        return ROOSGIKillbillInterceptor.<TenantUserApi>getProxy(super.getTenantUserApi(), TenantUserApi.class);
+    }
+
+    @Override
+    public UsageUserApi getUsageUserApi() {
+        return ROOSGIKillbillInterceptor.<UsageUserApi>getProxy(super.getUsageUserApi(), UsageUserApi.class);
+    }
+
+    @Override
+    public AuditUserApi getAuditUserApi() {
+        return ROOSGIKillbillInterceptor.<AuditUserApi>getProxy(super.getAuditUserApi(), AuditUserApi.class);
+    }
+
+    @Override
+    public CustomFieldUserApi getCustomFieldUserApi() {
+        return ROOSGIKillbillInterceptor.<CustomFieldUserApi>getProxy(super.getCustomFieldUserApi(), CustomFieldUserApi.class);
+    }
+
+    @Override
+    public ExportUserApi getExportUserApi() {
+        return ROOSGIKillbillInterceptor.<ExportUserApi>getProxy(super.getExportUserApi(), ExportUserApi.class);
+    }
+
+    @Override
+    public TagUserApi getTagUserApi() {
+        return ROOSGIKillbillInterceptor.<TagUserApi>getProxy(super.getTagUserApi(), TagUserApi.class);
+    }
+
+    @Override
+    public EntitlementApi getEntitlementApi() {
+        return ROOSGIKillbillInterceptor.<EntitlementApi>getProxy(super.getEntitlementApi(), EntitlementApi.class);
+    }
+
+    @Override
+    public RecordIdApi getRecordIdApi() {
+        return ROOSGIKillbillInterceptor.<RecordIdApi>getProxy(super.getRecordIdApi(), RecordIdApi.class);
+    }
+
+    @Override
+    public CurrencyConversionApi getCurrencyConversionApi() {
+        return ROOSGIKillbillInterceptor.<CurrencyConversionApi>getProxy(super.getCurrencyConversionApi(), CurrencyConversionApi.class);
+    }
+
+    @Override
+    public OverdueApi getOverdueApi() {
+        return ROOSGIKillbillInterceptor.<OverdueApi>getProxy(super.getOverdueApi(), OverdueApi.class);
+    }
+
+    @Override
+    public PluginConfigServiceApi getPluginConfigServiceApi() {
+        return ROOSGIKillbillInterceptor.<PluginConfigServiceApi>getProxy(super.getPluginConfigServiceApi(), PluginConfigServiceApi.class);
+    }
+
+    @Override
+    public SecurityApi getSecurityApi() {
+        return ROOSGIKillbillInterceptor.<SecurityApi>getProxy(super.getSecurityApi(), SecurityApi.class);
+    }
+
+    @Override
+    public PluginsInfoApi getPluginsInfoApi() {
+        return ROOSGIKillbillInterceptor.<PluginsInfoApi>getProxy(super.getPluginsInfoApi(), PluginsInfoApi.class);
+    }
+
+    @Override
+    public KillbillNodesApi getKillbillNodesApi() {
+        return ROOSGIKillbillInterceptor.<KillbillNodesApi>getProxy(super.getKillbillNodesApi(), KillbillNodesApi.class);
+    }
+
+    @Override
+    public AdminPaymentApi getAdminPaymentApi() {
+        return ROOSGIKillbillInterceptor.<AdminPaymentApi>getProxy(super.getAdminPaymentApi(), AdminPaymentApi.class);
+    }
+}


### PR DESCRIPTION
Use `ROOSGIKillbillAPI`, instead of `OSGIKillbillAPI`, to redirect reads to the RO DB instance, if configured.

See https://github.com/killbill/killbill-analytics-plugin/pull/80.