### PR TITLE
Created service-registry module and added eureka support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>osgi-bundles</module>
         <module>platform-test</module>
         <module>server</module>
+        <module>service-registry</module>
     </modules>
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-platform.git</connection>
@@ -158,6 +159,11 @@
                 <artifactId>killbill-platform-server</artifactId>
                 <version>${project.version}</version>
                 <classifier>classes</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.kill-bill.billing</groupId>
+                <artifactId>killbill-platform-service-registry</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.kill-bill.billing</groupId>

--- a/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
+++ b/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
@@ -68,8 +68,12 @@ public class KillbillHealthcheck extends HealthCheck {
         outOfRotation.set(false);
 
         for (ServiceRegistry serviceRegistry : serviceRegistries) {
-            logger.info("registering with " + serviceRegistry);
-            serviceRegistry.register();
+            logger.info("Registering ServiceRegistry {}", serviceRegistry);
+            try {
+                serviceRegistry.register();
+            } catch (RuntimeException e) {
+                logger.warn("Failed to register ServiceRegistry {}. Exception: {}", serviceRegistry, e);
+            }
         }
     }
 
@@ -79,7 +83,12 @@ public class KillbillHealthcheck extends HealthCheck {
         outOfRotation.set(true);
 
         for (ServiceRegistry serviceRegistry : serviceRegistries) {
-            serviceRegistry.unregister();
+            logger.info("Unregistering ServiceRegistry {}", serviceRegistry);
+            try {
+                serviceRegistry.unregister();
+            } catch (RuntimeException e) {
+                logger.warn("Failed to unregister ServiceRegistry {}. Exception: {}", serviceRegistry, e);
+            }
         }
     }
 

--- a/server/src/main/java/org/killbill/billing/server/healthchecks/ServiceRegistry.java
+++ b/server/src/main/java/org/killbill/billing/server/healthchecks/ServiceRegistry.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.healthchecks;
+
+public interface ServiceRegistry {
+
+    void register();
+
+    void unregister();
+}

--- a/service-registry/pom.xml
+++ b/service-registry/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <artifactId>killbill-platform-service-registry</artifactId>
     <packaging>jar</packaging>
-    <version>0.37.18-SNAPSHOT</version>
 
     <name>killbill-platform-service-registry</name>
     <properties>

--- a/service-registry/pom.xml
+++ b/service-registry/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2014-2018 Groupon, Inc
+  ~ Copyright 2014-2018 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>killbill-platform</artifactId>
+        <groupId>org.kill-bill.billing</groupId>
+        <version>0.37.16-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>killbill-platform-service-registry</artifactId>
+    <packaging>jar</packaging>
+    <name>killbill-platform-service-registry</name>
+    <properties>
+        <!-- http://jira.codehaus.org/browse/MRESOURCES-99 -->
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.netflix.eureka</groupId>
+            <artifactId>eureka-client</artifactId>
+            <version>1.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-platform-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-platform-server</artifactId>
+            <version>${project.version}</version>
+            <classifier>classes</classifier>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-killbill-platform-service-registry</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                            <filters>
+                                <filter>
+                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/service-registry/pom.xml
+++ b/service-registry/pom.xml
@@ -25,6 +25,8 @@
     </parent>
     <artifactId>killbill-platform-service-registry</artifactId>
     <packaging>jar</packaging>
+    <version>0.37.18-SNAPSHOT</version>
+
     <name>killbill-platform-service-registry</name>
     <properties>
         <!-- http://jira.codehaus.org/browse/MRESOURCES-99 -->
@@ -52,7 +54,6 @@
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-platform-server</artifactId>
-            <version>${project.version}</version>
             <classifier>classes</classifier>
         </dependency>
     </dependencies>
@@ -83,6 +84,16 @@
                                     <artifact>${project.groupId}:${project.artifactId}</artifact>
                                 </filter>
                             </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.shaded.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.sun.jersey</pattern>
+                                    <shadedPattern>com.shaded.sun.jersey</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaClientOptionalArgs.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaClientOptionalArgs.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+/**
+ * Default to a Jersey1 client. This can be overriden and injected with Guice
+ * using bind(EurekaClientOptionalArgs.class).to(MySubclassOptionalArgs.class).in(Scopes.SINGLETON);
+ */
+public class EurekaClientOptionalArgs extends AbstractDiscoveryClientOptionalArgs<ClientFilter> {
+    public EurekaClientOptionalArgs() {
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaModule.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaModule.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.providers.DefaultEurekaClientConfigProvider;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.platform.glue.KillBillPlatformModuleBase;
+import org.killbill.billing.server.healthchecks.ServiceRegistry;
+
+public class EurekaModule extends KillBillPlatformModuleBase {
+
+    public EurekaModule(final KillbillConfigSource configSource) {
+        super(configSource);
+    }
+
+    @Override
+    protected void configure() {
+        // need to eagerly initialize
+        bind(ApplicationInfoManager.class).asEagerSingleton();
+
+        bind(EurekaInstanceConfig.class).toProvider(KillbillEurekaInstanceConfigProvider.class).in(Scopes.SINGLETON);
+        bind(EurekaClientConfig.class).toProvider(DefaultEurekaClientConfigProvider.class).in(Scopes.SINGLETON);
+
+        // this is the self instanceInfo used for registration purposes
+        bind(InstanceInfo.class).toProvider(KillbillEurekaInstanceInfoProvider.class).in(Scopes.SINGLETON);
+
+        bind(EurekaClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
+
+        bind(AbstractDiscoveryClientOptionalArgs.class).to(EurekaClientOptionalArgs.class).in(Scopes.SINGLETON);
+
+
+        Multibinder<ServiceRegistry> serviceRegistryBinder = Multibinder.newSetBinder(binder(), ServiceRegistry.class);
+        serviceRegistryBinder.addBinding().to(EurekaServiceRegistry.class);
+
+
+    }
+
+    @Provides
+    KillbillConfigSource killbillConfigSource() {
+        return configSource;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && getClass().equals(obj.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaModule.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaModule.java
@@ -44,21 +44,17 @@ public class EurekaModule extends KillBillPlatformModuleBase {
         // need to eagerly initialize
         bind(ApplicationInfoManager.class).asEagerSingleton();
 
-        bind(EurekaInstanceConfig.class).toProvider(KillbillEurekaInstanceConfigProvider.class).in(Scopes.SINGLETON);
-        bind(EurekaClientConfig.class).toProvider(DefaultEurekaClientConfigProvider.class).in(Scopes.SINGLETON);
+        bind(EurekaInstanceConfig.class).toProvider(KillbillEurekaInstanceConfigProvider.class).asEagerSingleton();
+        bind(EurekaClientConfig.class).toProvider(DefaultEurekaClientConfigProvider.class).asEagerSingleton();
 
         // this is the self instanceInfo used for registration purposes
-        bind(InstanceInfo.class).toProvider(KillbillEurekaInstanceInfoProvider.class).in(Scopes.SINGLETON);
+        bind(InstanceInfo.class).toProvider(KillbillEurekaInstanceInfoProvider.class).asEagerSingleton();
 
-        bind(EurekaClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
-
-        bind(AbstractDiscoveryClientOptionalArgs.class).to(EurekaClientOptionalArgs.class).in(Scopes.SINGLETON);
-
+        bind(EurekaClient.class).to(DiscoveryClient.class).asEagerSingleton();
+        bind(AbstractDiscoveryClientOptionalArgs.class).to(EurekaClientOptionalArgs.class).asEagerSingleton();
 
         Multibinder<ServiceRegistry> serviceRegistryBinder = Multibinder.newSetBinder(binder(), ServiceRegistry.class);
         serviceRegistryBinder.addBinding().to(EurekaServiceRegistry.class);
-
-
     }
 
     @Provides

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaServiceRegistry.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/EurekaServiceRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+import org.killbill.billing.server.healthchecks.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.InstanceInfo;
+
+public class EurekaServiceRegistry implements ServiceRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(EurekaServiceRegistry.class);
+
+    private ApplicationInfoManager applicationInfoManager;
+
+    public static final String EUREKA_SERVICE_NAME = "eureka-service";
+
+    @Inject
+    public EurekaServiceRegistry(ApplicationInfoManager applicationInfoManager) {
+        this.applicationInfoManager = applicationInfoManager;
+    }
+
+    @Override
+    public void register() {
+        logger.info("--------------> Setting Eureka Status to UP <----------------");
+        applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.UP);
+        logger.info("--------------> Finished setting Eureka Status to UP <----------------");
+    }
+
+    @Override
+    public void unregister() {
+        logger.info("--------------> Setting Eureka Status to DOWN <----------------");
+        applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.DOWN);
+        logger.info("--------------> Finished setting Eureka Status to DOWN <----------------");
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceConfig.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+import javax.inject.Singleton;
+
+import com.google.common.base.Strings;
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.PropertiesInstanceConfig;
+
+@Singleton
+public class KillbillEurekaInstanceConfig extends PropertiesInstanceConfig implements EurekaInstanceConfig {
+
+    private String hostName;
+
+    public KillbillEurekaInstanceConfig() { }
+
+    public KillbillEurekaInstanceConfig(String namespace) {
+        super(namespace);
+    }
+
+    public KillbillEurekaInstanceConfig(String namespace, DataCenterInfo dataCenterInfo) {
+        super(namespace, dataCenterInfo);
+    }
+
+    @Override
+    public String getInstanceId() {
+        final String appName = getAppname();
+        final UUID uuid = UUID.randomUUID();
+        return appName + ":" + uuid.toString();
+    }
+
+    @Override
+    public String getHostName(boolean refresh) {
+        if(Strings.isNullOrEmpty(hostName)) {
+            determineHostName();
+        }
+        return hostName;
+    }
+
+    protected void determineHostName() {
+        try {
+            hostName = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Failed to get canonical hostname", e);
+        }
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceConfigProvider.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceConfigProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+import javax.inject.Provider;
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.discovery.DiscoveryManager;
+import com.netflix.discovery.EurekaNamespace;
+
+public class KillbillEurekaInstanceConfigProvider implements Provider<EurekaInstanceConfig> {
+    @Inject(optional = true)
+    @EurekaNamespace
+    private String namespace;
+
+    private KillbillEurekaInstanceConfig config;
+
+    @Override
+    public synchronized KillbillEurekaInstanceConfig get() {
+        if (config == null) {
+            if (namespace == null) {
+                config = new KillbillEurekaInstanceConfig();
+            } else {
+                config = new KillbillEurekaInstanceConfig(namespace);
+            }
+
+            // TODO: Remove this when DiscoveryManager is finally no longer used
+            DiscoveryManager.getInstance().setEurekaInstanceConfig(config);
+        }
+        return config;
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceInfoProvider.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceInfoProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.service.registry;
+
+import java.util.Map;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.killbill.CreatorName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.appinfo.InstanceInfo.PortType;
+import com.netflix.appinfo.LeaseInfo;
+import com.netflix.appinfo.UniqueIdentifier;
+import com.netflix.appinfo.providers.Archaius1VipAddressResolver;
+import com.netflix.appinfo.providers.VipAddressResolver;
+
+@Singleton
+public class KillbillEurekaInstanceInfoProvider implements Provider<InstanceInfo> {
+
+    private static final Logger logger = LoggerFactory.getLogger(KillbillEurekaInstanceInfoProvider.class);
+
+    private final EurekaInstanceConfig eurekaConfig;
+
+    private InstanceInfo instanceInfo;
+
+    @Inject(optional = true)
+    private VipAddressResolver vipAddressResolver = null;
+
+    @Inject
+    public KillbillEurekaInstanceInfoProvider(EurekaInstanceConfig eurekaConfig) {
+        this.eurekaConfig = eurekaConfig;
+    }
+
+    @Override
+    public synchronized InstanceInfo get() {
+        if (instanceInfo == null) {
+            // Build the lease information to be passed to the server based on eurekaConfig
+            LeaseInfo.Builder leaseInfoBuilder = LeaseInfo.Builder.newBuilder()
+                                                                  .setRenewalIntervalInSecs(eurekaConfig.getLeaseRenewalIntervalInSeconds())
+                                                                  .setDurationInSecs(eurekaConfig.getLeaseExpirationDurationInSeconds());
+
+            if (vipAddressResolver == null) {
+                vipAddressResolver = new Archaius1VipAddressResolver();
+            }
+
+            // Builder the instance information to be registered with eureka server
+            InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder(vipAddressResolver);
+
+            // set the appropriate id for the InstanceInfo, falling back to datacenter Id if applicable, else hostname
+            String instanceId = eurekaConfig.getInstanceId();
+            DataCenterInfo dataCenterInfo = eurekaConfig.getDataCenterInfo();
+            if (instanceId == null || instanceId.isEmpty()) {
+                if (dataCenterInfo instanceof UniqueIdentifier) {
+                    instanceId = ((UniqueIdentifier) dataCenterInfo).getId();
+                } else {
+                    instanceId = eurekaConfig.getHostName(false);
+                }
+            }
+
+            String hostName = CreatorName.get();
+
+            builder.setNamespace(eurekaConfig.getNamespace())
+                   .setInstanceId(instanceId)
+                   .setAppName(eurekaConfig.getAppname())
+                   .setAppGroupName(eurekaConfig.getAppGroupName())
+                   .setDataCenterInfo(eurekaConfig.getDataCenterInfo())
+                   .setIPAddr(eurekaConfig.getIpAddress())
+                   .setHostName(hostName)
+                   .setPort(eurekaConfig.getNonSecurePort())
+                   .enablePort(PortType.UNSECURE, eurekaConfig.isNonSecurePortEnabled())
+                   .setSecurePort(eurekaConfig.getSecurePort())
+                   .enablePort(PortType.SECURE, eurekaConfig.getSecurePortEnabled())
+                   .setVIPAddress(eurekaConfig.getVirtualHostName())
+                   .setSecureVIPAddress(eurekaConfig.getSecureVirtualHostName())
+                   .setHomePageUrl(eurekaConfig.getHomePageUrlPath(), eurekaConfig.getHomePageUrl())
+                   .setStatusPageUrl(eurekaConfig.getStatusPageUrlPath(), eurekaConfig.getStatusPageUrl())
+                   .setASGName(eurekaConfig.getASGName())
+                   .setHealthCheckUrls(eurekaConfig.getHealthCheckUrlPath(),
+                                       eurekaConfig.getHealthCheckUrl(), eurekaConfig.getSecureHealthCheckUrl());
+
+
+            // Start off with the STARTING state to avoid traffic
+            if (!eurekaConfig.isInstanceEnabledOnit()) {
+                InstanceStatus initialStatus = InstanceStatus.STARTING;
+                logger.info("Setting initial instance status as: " + initialStatus);
+                builder.setStatus(initialStatus);
+            } else {
+                logger.info("Setting initial instance status as: {}. This may be too early for the instance to advertise "
+                            + "itself as available. You would instead want to control this via a healthcheck handler.",
+                            InstanceStatus.UP);
+            }
+
+            // Add any user-specific metadata information
+            for (Map.Entry<String, String> mapEntry : eurekaConfig.getMetadataMap().entrySet()) {
+                String key = mapEntry.getKey();
+                String value = mapEntry.getValue();
+                builder.add(key, value);
+            }
+
+            instanceInfo = builder.build();
+            instanceInfo.setLeaseInfo(leaseInfoBuilder.build());
+        }
+        return instanceInfo;
+    }
+}

--- a/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceInfoProvider.java
+++ b/service-registry/src/main/java/org/killbill/billing/service/registry/KillbillEurekaInstanceInfoProvider.java
@@ -76,11 +76,11 @@ public class KillbillEurekaInstanceInfoProvider implements Provider<InstanceInfo
                 if (dataCenterInfo instanceof UniqueIdentifier) {
                     instanceId = ((UniqueIdentifier) dataCenterInfo).getId();
                 } else {
-                    instanceId = eurekaConfig.getHostName(false);
+                    instanceId = CreatorName.get();
                 }
             }
 
-            String hostName = CreatorName.get();
+            String hostName = eurekaConfig.getHostName(false);
 
             builder.setNamespace(eurekaConfig.getNamespace())
                    .setInstanceId(instanceId)


### PR DESCRIPTION
All the functionality from https://github.com/killbill/killbill/pull/986 is moved to this PR for killbill-platform. I made all the suggested improvements. 

I'm more familiar with gradle than maven, so can you check the pom.xml closely to see if I'm building the uber jar properly? Now there shouldn't be a direct dependency from the killbill package onto eureka (and jersey). Users can optionally add a dependency on killbill-platform-service-registry.