### PR TITLE
Introduce new ordering among Killbill Services to ensure initializati…

### DIFF
--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultBusService.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultBusService.java
@@ -26,7 +26,6 @@ import com.google.inject.Inject;
 
 public class DefaultBusService implements BusService {
 
-    public static final String EVENT_BUS_SERVICE = "bus-service";
 
     private final PersistentBus eventBus;
 
@@ -37,7 +36,12 @@ public class DefaultBusService implements BusService {
 
     @Override
     public String getName() {
-        return EVENT_BUS_SERVICE;
+        return KILLBILL_SERVICES.BUS_SERVICE.getServiceName() ;
+    }
+
+    @Override
+    public int getRegistrationOrdering() {
+        return KILLBILL_SERVICES.BUS_SERVICE.getRegistrationOrdering();
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.INIT_BUS)

--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultExternalBusService.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultExternalBusService.java
@@ -27,8 +27,6 @@ import com.google.inject.name.Named;
 
 public class DefaultExternalBusService implements ExternalBusService {
 
-    public static final String EXTERNAL_BUS_SERVICE = "external-bus-service";
-
     private final PersistentBus eventBus;
 
     @Inject
@@ -38,7 +36,12 @@ public class DefaultExternalBusService implements ExternalBusService {
 
     @Override
     public String getName() {
-        return EXTERNAL_BUS_SERVICE;
+        return KILLBILL_SERVICES.EXTERNAL_BUS_SERVICE.getServiceName() ;
+    }
+
+    @Override
+    public int getRegistrationOrdering() {
+        return KILLBILL_SERVICES.EXTERNAL_BUS_SERVICE.getRegistrationOrdering() ;
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.INIT_BUS)

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -44,7 +44,6 @@ import com.google.common.collect.ImmutableList;
 
 public class DefaultOSGIService implements OSGIService {
 
-    public static final String OSGI_SERVICE_NAME = "osgi-service";
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultOSGIService.class);
 
@@ -72,7 +71,12 @@ public class DefaultOSGIService implements OSGIService {
 
     @Override
     public String getName() {
-        return OSGI_SERVICE_NAME;
+        return KILLBILL_SERVICES.OSGI_SERVICE.getServiceName();
+    }
+
+    @Override
+    public int getRegistrationOrdering() {
+        return KILLBILL_SERVICES.OSGI_SERVICE.getRegistrationOrdering();
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.INIT_PLUGIN)

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
@@ -56,8 +56,6 @@ import com.google.common.eventbus.Subscribe;
 // Needs to be injected for the lifecycle logic
 public class KillbillEventRetriableBusHandler extends RetryableService implements KillbillEventRetriableBusHandlerService {
 
-    public static final String EXT_BUS_EVENT_LISTENER_SERVICE = "extBusEvent-listener-service";
-
     private final Logger logger = LoggerFactory.getLogger(KillbillEventRetriableBusHandler.class);
 
     private final PersistentBus externalBus;
@@ -98,7 +96,12 @@ public class KillbillEventRetriableBusHandler extends RetryableService implement
 
     @Override
     public String getName() {
-        return EXT_BUS_EVENT_LISTENER_SERVICE;
+        return KILLBILL_SERVICES.RETRIABLE_BUS_HANDLER_SERVICE.getServiceName();
+    }
+
+    @Override
+    public int getRegistrationOrdering() {
+        return KILLBILL_SERVICES.RETRIABLE_BUS_HANDLER_SERVICE.getRegistrationOrdering();
     }
 
     @LifecycleHandlerType(LifecycleLevel.INIT_SERVICE)

--- a/platform-api/src/main/java/org/killbill/billing/platform/api/KillbillService.java
+++ b/platform-api/src/main/java/org/killbill/billing/platform/api/KillbillService.java
@@ -53,4 +53,53 @@ public interface KillbillService {
      */
     public String getName();
 
+    /**
+     *
+     */
+    public int getRegistrationOrdering();
+
+    // Known services
+    public enum KILLBILL_SERVICES {
+
+        /* Platform range 0-100 */
+        NODES_SERVICE("nodes-service", 10),
+        BUS_SERVICE("bus-service", 20),
+        EXTERNAL_BUS_SERVICE("external-bus-service", 30),
+        SECURITY_SERVICE("security-service", 40),
+        CONFIG_SERVICE("config-service", 50),
+        BROADCAST_SERVICE("broadcast-service", 60),
+        RETRIABLE_BUS_HANDLER_SERVICE("extBusEvent-listener-service", 70),
+        /* Kill Bill core 100 - 500 */
+        TENANT_SERVICE("tenant-service", 110),
+        CATALOG_SERVICE("catalog-service", 120),
+        ACCOUNT_SERVICE("account-service", 130),
+        SUBSCRIPTION_BASE_SERVICE("subscription-service", 140),
+        ENTITLEMENT_SERVICE("entitlement-service", 150),
+        INVOICE_SERVICE("invoice-service", 160),
+        PAYMENT_SERVICE("payment-service", 170),
+        OVERDUE_SERVICE("overdue-service", 180),
+        CURRENCY_SERVICE("currency-service", 190),
+        JAXRS_SERVICE("jaxrs-service", 200),
+        /*  Apis, plugins, push notifications */
+        BEATRIX_SERVICE("beatrix-service", 500),
+        SERVER_SERVICE("server-service", 510),
+        OSGI_SERVICE("osgi-service", 520);
+
+        String serviceName;
+        int registrationOrdering;
+
+        KILLBILL_SERVICES(final String serviceName, final int registrationOrdering) {
+            this.serviceName = serviceName;
+            this.registrationOrdering = registrationOrdering;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public int getRegistrationOrdering() {
+            return registrationOrdering;
+        }
+    };
+
 }


### PR DESCRIPTION
…on of services is deterministic and follow bus event propagation. See #1032

In particular we are hoping to fix well known issues where various killbill services listen to same events and based on which bus event was registered
lead to different results -- e.g Payment service should process invoice bus events prior Overdue service.