### PR TITLE
Add support for env config

### DIFF
--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -20,47 +20,22 @@ package org.killbill.billing.platform.config;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import javax.annotation.Nullable;
 
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.xmlloader.UriAccessor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGIConfigProperties {
 
-    private static final String PROP_USER_TIME_ZONE = "user.timezone";
-    private static final String PROP_SECURITY_EGD = "java.security.egd";
-
-    private static final Logger logger = LoggerFactory.getLogger(DefaultKillbillConfigSource.class);
-    private static final String PROPERTIES_FILE = "org.killbill.server.properties";
-    private static final String GMT_ID = "GMT";
-
-    private static final String ENABLE_JASYPT_DECRYPTION = "org.killbill.server.enableJasypt";
-    private static final String JASYPT_ENCRYPTOR_PASSWORD_KEY = "JASYPT_ENCRYPTOR_PASSWORD";
-    private static final String JASYPT_ENCRYPTOR_ALGORITHM_KEY = "JASYPT_ENCRYPTOR_ALGORITHM";
-    private static final String ENC_PREFIX = "ENC(";
-    private static final String ENC_SUFFIX = ")";
-
-    private static final int NOT_SHOWN = 0;
-    private static final int SHOWN = 1;
-
-    private static volatile int GMT_WARNING = NOT_SHOWN;
-    private static volatile int ENTROPY_WARNING = NOT_SHOWN;
-
-    private final Properties properties;
+    private final PropertyKillbillConfigSource propertySource;
+    private final KillbillConfigSourceChain chain;
 
     public DefaultKillbillConfigSource() throws IOException, URISyntaxException {
         this((String) null);
@@ -75,196 +50,22 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
     }
 
     public DefaultKillbillConfigSource(@Nullable final String file, final Map<String, String> extraDefaultProperties) throws URISyntaxException, IOException {
-        if (file == null) {
-            this.properties = loadPropertiesFromFileOrSystemProperties();
-        } else {
-            this.properties = new Properties();
-            this.properties.load(UriAccessor.accessUri(this.getClass().getResource(file).toURI()));
-        }
-
-        for (final String key : extraDefaultProperties.keySet()) {
-            final String value = extraDefaultProperties.get(key);
-            if (value != null) {
-                properties.put(key, value);
-            }
-        }
-
-        populateDefaultProperties();
-
-        if (Boolean.parseBoolean(getString(ENABLE_JASYPT_DECRYPTION))) {
-            decryptJasyptProperties();
-        }
-    }
-
-    @Override
-    public String getString(final String propertyName) {
-        return properties.getProperty(propertyName);
+        this.propertySource = new PropertyKillbillConfigSource(file, extraDefaultProperties);
+        this.chain = new KillbillConfigSourceChain(ImmutableList.of(new EnvKillbillConfigSource(), propertySource));
     }
 
     @Override
     public Properties getProperties() {
-        return properties;
+        return propertySource.getProperties();
     }
 
-    private Properties loadPropertiesFromFileOrSystemProperties() {
-        // Chicken-egg problem. It would be nice to have the property in e.g. KillbillServerConfig,
-        // but we need to build the ConfigSource first...
-        final String propertiesFileLocation = System.getProperty(PROPERTIES_FILE);
-        if (propertiesFileLocation != null) {
-            try {
-                // Ignore System Properties if we're loading from a file
-                final Properties properties = new Properties();
-                properties.load(UriAccessor.accessUri(propertiesFileLocation));
-                return properties;
-            } catch (final IOException e) {
-                logger.warn("Unable to access properties file, defaulting to system properties", e);
-            } catch (final URISyntaxException e) {
-                logger.warn("Unable to access properties file, defaulting to system properties", e);
-            }
-        }
-
-        return new Properties(System.getProperties());
+    @Override
+    public String getString(final String propertyName) {
+        return chain.getString(propertyName);
     }
 
-    @VisibleForTesting
-    protected void populateDefaultProperties() {
-        final Properties defaultProperties = getDefaultProperties();
-        for (final String propertyName : defaultProperties.stringPropertyNames()) {
-            // Let the user override these properties
-            if (properties.get(propertyName) == null) {
-                properties.put(propertyName, defaultProperties.get(propertyName));
-            }
-        }
-
-        final Properties defaultSystemProperties = getDefaultSystemProperties();
-        for (final String propertyName : defaultSystemProperties.stringPropertyNames()) {
-
-            // Special case to overwrite user.timezone
-            if (propertyName.equals(PROP_USER_TIME_ZONE)) {
-                if (!"GMT".equals(System.getProperty(propertyName))) {
-                    if (GMT_WARNING == NOT_SHOWN) {
-                        synchronized (DefaultKillbillConfigSource.class) {
-                            if (GMT_WARNING == NOT_SHOWN) {
-                                GMT_WARNING = SHOWN;
-                                logger.info("Overwrite of user.timezone system property with {} may break database serialization of date. Kill Bill will overwrite to GMT",
-                                            System.getProperty(propertyName));
-                            }
-                        }
-                    }
-                }
-
-                //
-                // We now set the java system property -- regardless of whether this has been set previously or not.
-                // Also, setting java System property is not enough because default timezone may have been SET earlier,
-                // when first call to TimeZone.getDefaultRef was invoked-- which has a side effect to set it by either looking at
-                // existing "user.timezone" or being super smart by inferring from "user.country", "java.home", so we need to reset it.
-                //
-                System.setProperty(propertyName, GMT_ID);
-                TimeZone.setDefault(TimeZone.getTimeZone(GMT_ID));
-                continue;
-            }
-
-            // Let the user override these properties
-            if (System.getProperty(propertyName) == null) {
-                System.setProperty(propertyName, defaultSystemProperties.get(propertyName).toString());
-            }
-        }
-
-        // WARN for missing PROP_SECURITY_EGD
-        if (System.getProperty(PROP_SECURITY_EGD) == null) {
-            if (ENTROPY_WARNING == NOT_SHOWN) {
-                synchronized (DefaultKillbillConfigSource.class) {
-                    if (ENTROPY_WARNING == NOT_SHOWN) {
-                        ENTROPY_WARNING = SHOWN;
-                        logger.warn("System property {} has not been set, this may cause some requests to hang because of a lack of entropy. You should probably set it to 'file:/dev/./urandom'", PROP_SECURITY_EGD);
-                    }
-                }
-            }
-        }
-    }
-
-    @VisibleForTesting
-    public void setProperty(final String propertyName, final Object propertyValue) {
-        properties.put(propertyName, propertyValue);
-    }
-
-    @VisibleForTesting
-    protected Properties getDefaultProperties() {
-        final Properties properties = new Properties();
-        properties.put("org.killbill.persistent.bus.external.tableName", "bus_ext_events");
-        properties.put("org.killbill.persistent.bus.external.historyTableName", "bus_ext_events_history");
-        properties.put(ENABLE_JASYPT_DECRYPTION, "false");
-        return properties;
-    }
-
-    @VisibleForTesting
-    protected Properties getDefaultSystemProperties() {
-        final Properties properties = new Properties();
-        properties.put("user.timezone", GMT_ID);
-        properties.put("ANTLR_USE_DIRECT_CLASS_LOADING", "true");
-        // Disable log4jdbc-log4j2 by default.
-        // For slf4j-simple, this doesn't quite disable it (we cannot turn off the logger completely),
-        // but it should be off for logback (see logback.xml / logback-test.xml)
-        properties.put("org.slf4j.simpleLogger.log.jdbc", "ERROR");
-        // Sane defaults for https://code.google.com/p/log4jdbc-log4j2/
-        properties.put("log4jdbc.dump.sql.maxlinelength", "0");
-        properties.put("log4jdbc.spylogdelegator.name", "net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator");
-        return properties;
-    }
-
-    private void decryptJasyptProperties() {
-        String password = getEnvironmentVariable(JASYPT_ENCRYPTOR_PASSWORD_KEY, System.getProperty(JASYPT_ENCRYPTOR_PASSWORD_KEY));
-        String algorithm = getEnvironmentVariable(JASYPT_ENCRYPTOR_ALGORITHM_KEY, System.getProperty(JASYPT_ENCRYPTOR_ALGORITHM_KEY));
-
-        Enumeration keys = properties.keys();
-        StandardPBEStringEncryptor encryptor = initializeEncryptor(password, algorithm);
-        // Iterate over all properties and decrypt ones that match
-        while (keys.hasMoreElements()) {
-            final String key = (String) keys.nextElement();
-            final String value = (String) properties.get(key);
-            Optional<String> decryptableValue = decryptableValue(value);
-            if (decryptableValue.isPresent()) {
-                properties.setProperty(key, encryptor.decrypt(decryptableValue.get()));
-            }
-        }
-    }
-
-    private StandardPBEStringEncryptor initializeEncryptor(String password, String algorithm) {
-        StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-
-        if (Strings.isNullOrEmpty(password)) {
-            logger.error(JASYPT_ENCRYPTOR_PASSWORD_KEY + " is not set. Decrypting properties via Jasypt will likely fail.");
-        }
-        if (Strings.isNullOrEmpty(algorithm)) {
-            logger.error(JASYPT_ENCRYPTOR_ALGORITHM_KEY + " is not set. Decrypting properties via Jasypt will likely fail.");
-        }
-        encryptor.setPassword(password);
-        encryptor.setAlgorithm(algorithm);
-        return encryptor;
-    }
-
-    private String getEnvironmentVariable(String name, String defaultValue) {
-        String value = System.getenv(name);
-        if (!Strings.isNullOrEmpty(value)) {
-            return value;
-        }
-
-        value = getString(name);
-        return Strings.isNullOrEmpty(value) ? defaultValue : value;
-    }
-
-    private Optional<String> decryptableValue(String value) {
-        if (value == null) {
-            return Optional.absent();
-        }
-
-        int start = value.indexOf(ENC_PREFIX);
-        if (start != -1) {
-            int end = value.lastIndexOf(ENC_SUFFIX);
-            if (end != -1) {
-                return Optional.of(value.substring(start + ENC_PREFIX.length(), end));
-            }
-        }
-        return Optional.absent();
+    @Override
+    public boolean hasProperty(final String propertyName) {
+        return chain.hasProperty(propertyName);
     }
 }

--- a/base/src/main/java/org/killbill/billing/platform/config/EnvKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/EnvKillbillConfigSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.platform.config;
+
+import org.killbill.billing.platform.api.KillbillConfigSource;
+
+public class EnvKillbillConfigSource implements KillbillConfigSource {
+
+    static String propertyNameToEnvName(String propertyName) {
+        return propertyName.replaceAll("\\.", "_").toUpperCase();
+    }
+
+    @Override
+    public String getString(final String propertyName) {
+        return System.getenv().get(propertyNameToEnvName(propertyName));
+    }
+
+    @Override
+    public boolean hasProperty(final String propertyName) {
+        return System.getenv().containsKey(propertyNameToEnvName(propertyName));
+    }
+}

--- a/base/src/main/java/org/killbill/billing/platform/config/KillbillConfigSourceChain.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/KillbillConfigSourceChain.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.platform.config;
+
+import java.util.List;
+
+import org.killbill.billing.platform.api.KillbillConfigSource;
+
+public class KillbillConfigSourceChain implements KillbillConfigSource {
+
+    private final List<KillbillConfigSource> sources;
+
+    public KillbillConfigSourceChain(List<KillbillConfigSource> sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    public String getString(final String propertyName) {
+        return sources.stream()
+                      .filter(source -> source.hasProperty(propertyName))
+                      .map(source -> source.getString(propertyName))
+                      .findFirst()
+                      .orElse(null);
+    }
+
+    @Override
+    public boolean hasProperty(final String propertyName) {
+        return sources.stream().anyMatch(source -> source.hasProperty(propertyName));
+    }
+}

--- a/base/src/main/java/org/killbill/billing/platform/config/PropertyKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/PropertyKillbillConfigSource.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.platform.config;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import javax.annotation.Nullable;
+
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.killbill.billing.osgi.api.OSGIConfigProperties;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.xmlloader.UriAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+public class PropertyKillbillConfigSource implements KillbillConfigSource, OSGIConfigProperties {
+
+    private static final String PROP_USER_TIME_ZONE = "user.timezone";
+    private static final String PROP_SECURITY_EGD = "java.security.egd";
+
+    private static final Logger logger = LoggerFactory.getLogger(PropertyKillbillConfigSource.class);
+    private static final String PROPERTIES_FILE = "org.killbill.server.properties";
+    private static final String GMT_ID = "GMT";
+
+    private static final String ENABLE_JASYPT_DECRYPTION = "org.killbill.server.enableJasypt";
+    private static final String JASYPT_ENCRYPTOR_PASSWORD_KEY = "JASYPT_ENCRYPTOR_PASSWORD";
+    private static final String JASYPT_ENCRYPTOR_ALGORITHM_KEY = "JASYPT_ENCRYPTOR_ALGORITHM";
+    private static final String ENC_PREFIX = "ENC(";
+    private static final String ENC_SUFFIX = ")";
+
+    private static final int NOT_SHOWN = 0;
+    private static final int SHOWN = 1;
+
+    private static volatile int GMT_WARNING = NOT_SHOWN;
+    private static volatile int ENTROPY_WARNING = NOT_SHOWN;
+
+    private final Properties properties;
+
+    public PropertyKillbillConfigSource() throws IOException, URISyntaxException {
+        this((String) null);
+    }
+
+    public PropertyKillbillConfigSource(final Map<String, String> extraDefaultProperties) throws IOException, URISyntaxException {
+        this(null, extraDefaultProperties);
+    }
+
+    public PropertyKillbillConfigSource(@Nullable final String file) throws URISyntaxException, IOException {
+        this(file, ImmutableMap.<String, String>of());
+    }
+
+    public PropertyKillbillConfigSource(@Nullable final String file, final Map<String, String> extraDefaultProperties) throws URISyntaxException, IOException {
+        if (file == null) {
+            this.properties = loadPropertiesFromFileOrSystemProperties();
+        } else {
+            this.properties = new Properties();
+            this.properties.load(UriAccessor.accessUri(this.getClass().getResource(file).toURI()));
+        }
+
+        for (final String key : extraDefaultProperties.keySet()) {
+            final String value = extraDefaultProperties.get(key);
+            if (value != null) {
+                properties.put(key, value);
+            }
+        }
+
+        populateDefaultProperties();
+
+        if (Boolean.parseBoolean(getString(ENABLE_JASYPT_DECRYPTION))) {
+            decryptJasyptProperties();
+        }
+    }
+
+    @Override
+    public String getString(final String propertyName) {
+        return properties.getProperty(propertyName);
+    }
+
+    @Override
+    public boolean hasProperty(final String propertyName) {
+        return properties.containsKey(propertyName);
+    }
+
+    @Override
+    public Properties getProperties() {
+        return properties;
+    }
+
+    private Properties loadPropertiesFromFileOrSystemProperties() {
+        // Chicken-egg problem. It would be nice to have the property in e.g. KillbillServerConfig,
+        // but we need to build the ConfigSource first...
+        final String propertiesFileLocation = System.getProperty(PROPERTIES_FILE);
+        if (propertiesFileLocation != null) {
+            try {
+                // Ignore System Properties if we're loading from a file
+                final Properties properties = new Properties();
+                properties.load(UriAccessor.accessUri(propertiesFileLocation));
+                return properties;
+            } catch (final IOException e) {
+                logger.warn("Unable to access properties file, defaulting to system properties", e);
+            } catch (final URISyntaxException e) {
+                logger.warn("Unable to access properties file, defaulting to system properties", e);
+            }
+        }
+
+        return new Properties(System.getProperties());
+    }
+
+    @VisibleForTesting
+    protected void populateDefaultProperties() {
+        final Properties defaultProperties = getDefaultProperties();
+        for (final String propertyName : defaultProperties.stringPropertyNames()) {
+            // Let the user override these properties
+            if (properties.get(propertyName) == null) {
+                properties.put(propertyName, defaultProperties.get(propertyName));
+            }
+        }
+
+        final Properties defaultSystemProperties = getDefaultSystemProperties();
+        for (final String propertyName : defaultSystemProperties.stringPropertyNames()) {
+
+            // Special case to overwrite user.timezone
+            if (propertyName.equals(PROP_USER_TIME_ZONE)) {
+                if (!"GMT".equals(System.getProperty(propertyName))) {
+                    if (GMT_WARNING == NOT_SHOWN) {
+                        synchronized (PropertyKillbillConfigSource.class) {
+                            if (GMT_WARNING == NOT_SHOWN) {
+                                GMT_WARNING = SHOWN;
+                                logger.info("Overwrite of user.timezone system property with {} may break database serialization of date. Kill Bill will overwrite to GMT",
+                                            System.getProperty(propertyName));
+                            }
+                        }
+                    }
+                }
+
+                //
+                // We now set the java system property -- regardless of whether this has been set previously or not.
+                // Also, setting java System property is not enough because default timezone may have been SET earlier,
+                // when first call to TimeZone.getDefaultRef was invoked-- which has a side effect to set it by either looking at
+                // existing "user.timezone" or being super smart by inferring from "user.country", "java.home", so we need to reset it.
+                //
+                System.setProperty(propertyName, GMT_ID);
+                TimeZone.setDefault(TimeZone.getTimeZone(GMT_ID));
+                continue;
+            }
+
+            // Let the user override these properties
+            if (System.getProperty(propertyName) == null) {
+                System.setProperty(propertyName, defaultSystemProperties.get(propertyName).toString());
+            }
+        }
+
+        // WARN for missing PROP_SECURITY_EGD
+        if (System.getProperty(PROP_SECURITY_EGD) == null) {
+            if (ENTROPY_WARNING == NOT_SHOWN) {
+                synchronized (PropertyKillbillConfigSource.class) {
+                    if (ENTROPY_WARNING == NOT_SHOWN) {
+                        ENTROPY_WARNING = SHOWN;
+                        logger.warn("System property {} has not been set, this may cause some requests to hang because of a lack of entropy. You should probably set it to 'file:/dev/./urandom'", PROP_SECURITY_EGD);
+                    }
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public void setProperty(final String propertyName, final Object propertyValue) {
+        properties.put(propertyName, propertyValue);
+    }
+
+    @VisibleForTesting
+    protected Properties getDefaultProperties() {
+        final Properties properties = new Properties();
+        properties.put("org.killbill.persistent.bus.external.tableName", "bus_ext_events");
+        properties.put("org.killbill.persistent.bus.external.historyTableName", "bus_ext_events_history");
+        properties.put(ENABLE_JASYPT_DECRYPTION, "false");
+        return properties;
+    }
+
+    @VisibleForTesting
+    protected Properties getDefaultSystemProperties() {
+        final Properties properties = new Properties();
+        properties.put("user.timezone", GMT_ID);
+        properties.put("ANTLR_USE_DIRECT_CLASS_LOADING", "true");
+        // Disable log4jdbc-log4j2 by default.
+        // For slf4j-simple, this doesn't quite disable it (we cannot turn off the logger completely),
+        // but it should be off for logback (see logback.xml / logback-test.xml)
+        properties.put("org.slf4j.simpleLogger.log.jdbc", "ERROR");
+        // Sane defaults for https://code.google.com/p/log4jdbc-log4j2/
+        properties.put("log4jdbc.dump.sql.maxlinelength", "0");
+        properties.put("log4jdbc.spylogdelegator.name", "net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator");
+        return properties;
+    }
+
+    private void decryptJasyptProperties() {
+        String password = getEnvironmentVariable(JASYPT_ENCRYPTOR_PASSWORD_KEY, System.getProperty(JASYPT_ENCRYPTOR_PASSWORD_KEY));
+        String algorithm = getEnvironmentVariable(JASYPT_ENCRYPTOR_ALGORITHM_KEY, System.getProperty(JASYPT_ENCRYPTOR_ALGORITHM_KEY));
+
+        Enumeration keys = properties.keys();
+        StandardPBEStringEncryptor encryptor = initializeEncryptor(password, algorithm);
+        // Iterate over all properties and decrypt ones that match
+        while (keys.hasMoreElements()) {
+            final String key = (String) keys.nextElement();
+            final String value = (String) properties.get(key);
+            Optional<String> decryptableValue = decryptableValue(value);
+            if (decryptableValue.isPresent()) {
+                properties.setProperty(key, encryptor.decrypt(decryptableValue.get()));
+            }
+        }
+    }
+
+    private StandardPBEStringEncryptor initializeEncryptor(String password, String algorithm) {
+        StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
+
+        if (Strings.isNullOrEmpty(password)) {
+            logger.error(JASYPT_ENCRYPTOR_PASSWORD_KEY + " is not set. Decrypting properties via Jasypt will likely fail.");
+        }
+        if (Strings.isNullOrEmpty(algorithm)) {
+            logger.error(JASYPT_ENCRYPTOR_ALGORITHM_KEY + " is not set. Decrypting properties via Jasypt will likely fail.");
+        }
+        encryptor.setPassword(password);
+        encryptor.setAlgorithm(algorithm);
+        return encryptor;
+    }
+
+    private String getEnvironmentVariable(String name, String defaultValue) {
+        String value = System.getenv(name);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+
+        value = getString(name);
+        return Strings.isNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    private Optional<String> decryptableValue(String value) {
+        if (value == null) {
+            return Optional.absent();
+        }
+
+        int start = value.indexOf(ENC_PREFIX);
+        if (start != -1) {
+            int end = value.lastIndexOf(ENC_SUFFIX);
+            if (end != -1) {
+                return Optional.of(value.substring(start + ENC_PREFIX.length(), end));
+            }
+        }
+        return Optional.absent();
+    }
+}

--- a/base/src/test/java/org/killbill/billing/platform/config/TestEnvKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestEnvKillbillConfigSource.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -15,12 +15,19 @@
  * under the License.
  */
 
-package org.killbill.billing.platform.api;
+package org.killbill.billing.platform.config;
 
-public interface KillbillConfigSource {
+import java.io.IOException;
+import java.net.URISyntaxException;
 
-    String getString(String propertyName);
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
-    boolean hasProperty(String propertyName);
+public class TestEnvKillbillConfigSource {
 
+    @Test(groups = "fast")
+    public void testNameMapping() throws IOException, URISyntaxException {
+        String name = EnvKillbillConfigSource.propertyNameToEnvName("killbill.test.prop");
+        Assert.assertEquals(name, "KILLBILL_TEST_PROP");
+    }
 }

--- a/base/src/test/java/org/killbill/billing/platform/config/TestPropertyKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestPropertyKillbillConfigSource.java
@@ -29,7 +29,7 @@ import org.testng.Assert;
 
 import com.google.common.collect.ImmutableMap;
 
-public class TestDefaultKillbillConfigSource {
+public class TestPropertyKillbillConfigSource {
 
     private static final String ENABLE_JASYPT_PROPERTY = "org.killbill.server.enableJasypt";
     private static final String JASYPT_ENCRYPTOR_PASSWORD_PROPERTY = "JASYPT_ENCRYPTOR_PASSWORD";
@@ -53,7 +53,7 @@ public class TestDefaultKillbillConfigSource {
 
     @Test(groups = "fast")
     public void testJasyptDisabledByDefault() throws IOException, URISyntaxException {
-        DefaultKillbillConfigSource configSource = new DefaultKillbillConfigSource();
+        PropertyKillbillConfigSource configSource = new PropertyKillbillConfigSource();
 
         String enableJasyptString = configSource.getString(ENABLE_JASYPT_PROPERTY);
 
@@ -70,7 +70,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
-        DefaultKillbillConfigSource configSource = new DefaultKillbillConfigSource(properties);
+        PropertyKillbillConfigSource configSource = new PropertyKillbillConfigSource(properties);
 
         String actualValue = configSource.getString(ENCRYPTED_PROPERTY_1);
 
@@ -86,7 +86,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, "",
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
-        new DefaultKillbillConfigSource(properties);
+        new PropertyKillbillConfigSource(properties);
     }
 
     @Test(groups = "fast", expectedExceptions = IllegalArgumentException.class)
@@ -98,7 +98,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, "");
 
-        new DefaultKillbillConfigSource(properties);
+        new PropertyKillbillConfigSource(properties);
     }
 
     @Test(groups = "fast", expectedExceptions = EncryptionOperationNotPossibleException.class)
@@ -110,7 +110,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
-        new DefaultKillbillConfigSource(properties);
+        new PropertyKillbillConfigSource(properties);
     }
 
     @Test(groups = "fast", expectedExceptions = EncryptionOperationNotPossibleException.class)
@@ -122,7 +122,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
-        new DefaultKillbillConfigSource(properties);
+        new PropertyKillbillConfigSource(properties);
     }
 
     @Test(groups = "fast")
@@ -138,7 +138,7 @@ public class TestDefaultKillbillConfigSource {
                                                          JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
                                                          JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
-        DefaultKillbillConfigSource configSource = new DefaultKillbillConfigSource(properties);
+        PropertyKillbillConfigSource configSource = new PropertyKillbillConfigSource(properties);
 
         String actualValue1 = configSource.getString(ENCRYPTED_PROPERTY_1);
         String actualValue2 = configSource.getString(ENCRYPTED_PROPERTY_2);

--- a/platform-test/src/main/java/org/killbill/billing/platform/test/config/TestKillbillConfigSource.java
+++ b/platform-test/src/main/java/org/killbill/billing/platform/test/config/TestKillbillConfigSource.java
@@ -27,14 +27,15 @@ import java.util.Properties;
 import javax.annotation.Nullable;
 
 import org.killbill.billing.platform.config.DefaultKillbillConfigSource;
+import org.killbill.billing.platform.config.PropertyKillbillConfigSource;
 import org.killbill.billing.platform.test.PlatformDBTestingHelper;
 import org.killbill.commons.embeddeddb.EmbeddedDB;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 
-public class TestKillbillConfigSource extends DefaultKillbillConfigSource {
 
+public class TestKillbillConfigSource extends PropertyKillbillConfigSource {
     private final String jdbcConnectionString;
     private final String jdbcUsername;
     private final String jdbcPassword;


### PR DESCRIPTION
* Add `hasProperty` method to `KillbillConfigSource` interface.
* Rename `DefaultKillbillConfigSource` to `PropertyKillbillConfigSource`.
* Add `KillbillConfigSourceChain`, which allows chaining multiple config sources together to sequentially look for config values.
* Add `EnvKillbillConfigSource`, which reads config values from the system environment.
* Create new `DefaultKillbillConfigSource` which uses a chain of `EnvKillbillConfigSource` and  `PropertyKillbillConfigSource`.