### PR TITLE
lifecycle: Add a new START_BUS lifecyle level

### DIFF
--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultBusService.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultBusService.java
@@ -20,6 +20,7 @@ package org.killbill.billing.lifecycle.bus;
 
 import org.killbill.billing.lifecycle.api.BusService;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
+import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.bus.api.PersistentBus;
 
 import com.google.inject.Inject;
@@ -45,13 +46,18 @@ public class DefaultBusService implements BusService {
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.INIT_BUS)
+    public void initBus() {
+        eventBus.initQueue();
+    }
+
+    @LifecycleHandlerType(LifecycleLevel.START_BUS)
     public void startBus() {
-        eventBus.start();
+        eventBus.startQueue();
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.STOP_BUS)
     public void stopBus() {
-        eventBus.stop();
+        eventBus.stopQueue();
     }
 
     @Override

--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultExternalBusService.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/DefaultExternalBusService.java
@@ -20,6 +20,7 @@ package org.killbill.billing.lifecycle.bus;
 import org.killbill.billing.lifecycle.api.ExternalBusService;
 import org.killbill.billing.lifecycle.glue.BusModule;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
+import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.bus.api.PersistentBus;
 
 import com.google.inject.Inject;
@@ -45,13 +46,18 @@ public class DefaultExternalBusService implements ExternalBusService {
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.INIT_BUS)
+    public void initBus() {
+        eventBus.initQueue();
+    }
+
+    @LifecycleHandlerType(LifecycleLevel.START_BUS)
     public void startBus() {
-        eventBus.start();
+        eventBus.startQueue();
     }
 
     @LifecycleHandlerType(LifecycleHandlerType.LifecycleLevel.STOP_BUS)
     public void stopBus() {
-        eventBus.stop();
+        eventBus.stopQueue();
     }
 
     @Override

--- a/platform-api/src/main/java/org/killbill/billing/platform/api/LifecycleHandlerType.java
+++ b/platform-api/src/main/java/org/killbill/billing/platform/api/LifecycleHandlerType.java
@@ -63,11 +63,16 @@ public @interface LifecycleHandlerType {
         START_PLUGIN(Sequence.STARTUP_PRE_EVENT_REGISTRATION),
         /**
          * Service start
-         * - API call should not work
+         * - API call should work
          * - Events might be triggered
          * - Batch processing jobs started
          */
         START_SERVICE(Sequence.STARTUP_POST_EVENT_REGISTRATION),
+        /**
+         * Start event bus (only for the event bus)
+         */
+        START_BUS(Sequence.STARTUP_POST_EVENT_REGISTRATION),
+
         /**
          * Stop service
          */

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.143.51</version>
+        <version>0.143.56-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.39.14-SNAPSHOT</version>


### PR DESCRIPTION
The idea is to only start processing bus events after plugin and KillBill service have been started to make sure such processing will happen on a fully initialized stack.