### PR TITLE
Update Jersey from 1.19.4 to 2.32

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -26,6 +26,24 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+    </JetCodeStyleSettings>
     <XML>
       <option name="XML_ATTRIBUTE_WRAP" value="0" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.40.6
+    Update to killbill-oss-parent 0.144.46 (Jersey 2.x)
+
 0.40.5
     Update to killbill-oss-parent 0.144.40
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.36</version>
+        <version>0.144.38-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.40.5-SNAPSHOT</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,12 +36,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.dmurph</groupId>
@@ -63,12 +61,10 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <!-- Needed by jmxutils -->
@@ -79,7 +75,6 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.izettle</groupId>
@@ -142,11 +137,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-guice</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <scope>runtime</scope>
@@ -174,7 +164,6 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-logback</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -195,6 +184,11 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -406,19 +400,20 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-core</artifactId>
-                        <version>${logback.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <webAppSourceDirectory>${basedir}/src/main/webapp</webAppSourceDirectory>
                     <systemProperties>
                         <systemProperty>
                             <name>logback.configurationFile</name>
                             <value>file:${basedir}/src/main/webapp/logback.xml</value>
+                        </systemProperty>
+                        <systemProperty>
+                            <name>org.killbill.dao.seedFile</name>
+                            <value>file:${basedir}/src/main/resources/org/killbill/billing/server/ddl.sql</value>
+                        </systemProperty>
+                        <systemProperty>
+                            <name>org.killbill.server.updateCheck.skip</name>
+                            <value>true</value>
                         </systemProperty>
                     </systemProperties>
                 </configuration>

--- a/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
+++ b/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
@@ -44,7 +44,7 @@ public class KillbillHealthcheck extends HealthCheck {
     private Set<ServiceRegistry> serviceRegistries = Collections.emptySet();
 
     @Inject(optional=true)
-    public void setServiceRegistries(Set<ServiceRegistry> serviceRegistries) {
+    public void setServiceRegistries(final Set<ServiceRegistry> serviceRegistries) {
         this.serviceRegistries = serviceRegistries;
     }
 

--- a/server/src/main/java/org/killbill/billing/server/listeners/KillbillPlatformGuiceListener.java
+++ b/server/src/main/java/org/killbill/billing/server/listeners/KillbillPlatformGuiceListener.java
@@ -47,7 +47,6 @@ import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.killbill.commons.skeleton.listeners.GuiceServletContextListener;
 import org.killbill.commons.skeleton.modules.BaseServerModuleBuilder;
 import org.killbill.commons.skeleton.modules.JMXModule;
-import org.killbill.commons.skeleton.modules.JaxrsJacksonModule;
 import org.killbill.commons.skeleton.modules.StatsModule;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.config.ConfigSource;
@@ -174,7 +173,6 @@ public class KillbillPlatformGuiceListener extends GuiceServletContextListener {
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         guiceModules = ImmutableList.<Module>of(getServletModule(),
-                                                getJacksonModule(),
                                                 new JMXModule(KillbillHealthcheck.class, KillbillQueuesHealthcheck.class, NotificationQueueService.class, PersistentBus.class),
                                                 new StatsModule(METRICS_SERVLETS_PATHS.get(0),
                                                                 METRICS_SERVLETS_PATHS.get(1),
@@ -207,13 +205,6 @@ public class KillbillPlatformGuiceListener extends GuiceServletContextListener {
 
     protected Module getModule(final ServletContext servletContext) {
         return new KillbillPlatformModule(servletContext, config, configSource);
-    }
-
-    protected JaxrsJacksonModule getJacksonModule() {
-        final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JodaModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        return new JaxrsJacksonModule(objectMapper);
     }
 
     protected void initializeMetrics(final ServletContextEvent event) {

--- a/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
@@ -19,8 +19,11 @@
 
 package org.killbill.billing.server.modules;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.SQLException;
 
@@ -78,7 +81,15 @@ public class EmbeddedDBProvider implements Provider<EmbeddedDB> {
         }
 
         for (final String ddlFile : getDDLFiles()) {
-            final URL resource = Resources.getResource(ddlFile);
+            final URL resource;
+            try {
+                final URI uri = new URI(ddlFile);
+                final String scheme = uri.getScheme();
+                resource = scheme == null ? Resources.getResource(ddlFile) : new File(uri.getSchemeSpecificPart()).toURI().toURL();
+            } catch (final URISyntaxException e) {
+                throw new IllegalStateException(e);
+            }
+
             final InputStream inputStream = resource.openStream();
             try {
                 final String ddl = streamToString(inputStream);
@@ -91,7 +102,7 @@ public class EmbeddedDBProvider implements Provider<EmbeddedDB> {
     }
 
     protected Iterable<String> getDDLFiles() {
-        return ImmutableList.<String>of("org/killbill/billing/server/ddl.sql");
+        return ImmutableList.<String>of(System.getProperty("org.killbill.dao.seedFile", "org/killbill/billing/server/ddl.sql"));
     }
 
     protected String streamToString(final InputStream inputStream) throws IOException {

--- a/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/EmbeddedDBProvider.java
@@ -102,7 +102,8 @@ public class EmbeddedDBProvider implements Provider<EmbeddedDB> {
     }
 
     protected Iterable<String> getDDLFiles() {
-        return ImmutableList.<String>of(System.getProperty("org.killbill.dao.seedFile", "org/killbill/billing/server/ddl.sql"));
+        final String seedFile = System.getProperty("org.killbill.dao.seedFile");
+        return seedFile == null ? ImmutableList.<String>of() : ImmutableList.<String>of(seedFile);
     }
 
     protected String streamToString(final InputStream inputStream) throws IOException {

--- a/server/src/main/java/org/killbill/billing/server/modules/KillbillPlatformModule.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/KillbillPlatformModule.java
@@ -51,6 +51,9 @@ import org.skife.jdbi.v2.tweak.TransactionHandler;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jdbi.InstrumentedTimingCollector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
@@ -78,6 +81,7 @@ public class KillbillPlatformModule extends KillBillPlatformModuleBase {
 
     @Override
     protected void configure() {
+        configureJackson();
         configureClock();
         configureDao();
         configureConfig();
@@ -87,6 +91,13 @@ public class KillbillPlatformModule extends KillBillPlatformModuleBase {
         configureNotificationQ();
         configureOSGI();
         configureJNDI();
+    }
+
+    protected void configureJackson() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JodaModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        bind(ObjectMapper.class).toInstance(objectMapper);
     }
 
     protected void configureClock() {

--- a/server/src/main/webapp/index.html
+++ b/server/src/main/webapp/index.html
@@ -40,7 +40,6 @@
                       <div class="nav-collapse collapse">
                           <ul class="nav pull-right">
                               <li><a href="http://groups.google.com/group/killbilling-users" target="_blank">User Mailing-List</a></li>
-                              <li><a href="http://groups.google.com/group/killbilling-dev" target="_blank">Dev Mailing-List</a></li>
                           </ul>
                       </div>
                   </div>


### PR DESCRIPTION
This also fixes the `EmbeddedDBProvider` on standalone H2, as well as the `jetty:run` Maven goal, which looked broken for a while.

This addresses wave 3 of killbill/killbill-oss-parent#34.