### PR TITLE
server: Add shutdown hook to handle SIGTERM

### DIFF
--- a/server/src/main/java/org/killbill/billing/server/listeners/KillbillPlatformGuiceListener.java
+++ b/server/src/main/java/org/killbill/billing/server/listeners/KillbillPlatformGuiceListener.java
@@ -128,28 +128,34 @@ public class KillbillPlatformGuiceListener extends GuiceServletContextListener {
 
         startLifecycle();
 
+        final Thread shutdownListener = new Thread() {
+            public void run() {
+                logger.info("shutdownListener invoking shutdown sequence");
+                shutdownSequence();
+            }
+        };
+        Runtime.getRuntime().addShutdownHook(shutdownListener);
+
         // The host will be put in rotation in KillbillGuiceFilter, once Jersey is fully initialized
     }
 
     @Override
     public void contextDestroyed(final ServletContextEvent sce) {
         putOutOfRotation();
-
         super.contextDestroyed(sce);
+        shutdownSequence();
+    }
 
+    private void shutdownSequence() {
         // Guice error, no need to fill the screen with useless stack traces
         if (killbillLifecycle == null) {
             return;
         }
 
         stopLifecycle();
-
         stopEmbeddedDBs();
-
         stopMetrics();
-
         removeJMXExports();
-
         stopLogging();
     }
 


### PR DESCRIPTION
In k8s environment, and in normal circumstances, PODs are being terminated by receiving a SIGTERM.
The code adds a shutdown hook to properly call the Kill Bill shutdown sequence and perform correct cleanup (e.g nodeInfo)

See this blog post for more info on k8s sequence: https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace

Note that we could also leverage the k8s `PreStop` method to call ourselves the stop sequence (e.g tomcat#stop). See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/