### PR TITLE
Add support for more recent JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   - workflow_dispatch
 
 env:
-  MAVEN_FLAGS: "-B --no-transfer-progress"
+  MAVEN_FLAGS: "-e -B --no-transfer-progress"
   MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3"
 
 jobs:
@@ -16,24 +16,99 @@ jobs:
       matrix:
         java-version:
           - 8
+          - 11
+        java-distribution:
+          - adopt
+          - zulu
         profile:
           - travis
           - mysql
           - postgresql
     steps:
-      - name: Checkout code
+      - name: Checkout killbill-platform
         uses: actions/checkout@v2
-      - name: Setup Java
-        uses: actions/setup-java@v1
         with:
+          repository: killbill/killbill-platform
+          ref: ${{ github.ref }}
+          path: killbill-platform
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
       - name: Configure Sonatype mirror
         uses: s4u/maven-settings-action@v2.3.0
         # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
+      - name: Check if killbill-oss-parent SNAPSHOT must be fetched
+        id: killbill-oss-parent
+        run: |
+          REMOTE_SHA=$(git ls-remote --heads https://github.com/killbill/killbill-oss-parent.git ${GITHUB_REF##*/})
+          echo "killbill-oss-parent branch=${GITHUB_REF##*/} sha=${REMOTE_SHA}"
+          cd $GITHUB_WORKSPACE/killbill-platform
+          # Cannot use mvn help:evaluate unfortunately, as the project isn't buildable yet
+          PARENT_POM_VERSION=$(
+             awk '
+              /<dependenc/{exit}
+              /<parent>/{parent++};
+              /<version>/{
+                if (parent == 1) {
+                  sub(/.*<version>/, "");
+                  sub(/<.*/, "");
+                  parent_version = $0;
+                }
+              }
+              /<\/parent>/{parent--};
+              END {
+                print parent_version
+              }' pom.xml
+          )
+          echo "killbill-oss-parent version=${PARENT_POM_VERSION}"
+          if [[ "$PARENT_POM_VERSION" =~ .*"-SNAPSHOT".* ]] && [ ! -z "$REMOTE_SHA" ]; then
+            echo "::set-output name=FETCH_SNAPSHOT::true"
+          else
+            echo "::set-output name=FETCH_SNAPSHOT::false"
+          fi
+      - name: Checkout killbill-oss-parent
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-oss-parent
+          ref: ${{ github.ref }}
+          path: killbill-oss-parent
+      - name: Build killbill-oss-parent
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-oss-parent
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-commons
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-commons
+          ref: ${{ github.ref }}
+          path: killbill-commons
+      - name: Build killbill-commons
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-commons
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-plugin-framework-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-plugin-framework-java
+          ref: ${{ github.ref }}
+          path: killbill-plugin-framework-java
+      - name: Build killbill-plugin-framework-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-plugin-framework-java
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
       - name: Tests
         env:
           MAVEN_PROFILE: ${{ matrix.profile }}
         run: |
+          cd $GITHUB_WORKSPACE/killbill-platform
           mvn ${MAVEN_FLAGS} clean install -P${MAVEN_PROFILE}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,120 @@
+name: "CodeQL"
+
+on:
+  - push
+  - workflow_dispatch
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 8
+        java-distribution:
+          - adopt
+        language: ['java']
+    steps:
+    - name: Checkout killbill-platform
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-platform
+        ref: ${{ github.ref }}
+        path: killbill-platform
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: ${{ matrix.java-distribution }}
+        java-version: ${{ matrix.java-version }}
+    - name: Configure Sonatype mirror
+      uses: s4u/maven-settings-action@v2.3.0
+      # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
+      with:
+        mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
+    - name: Check if killbill-oss-parent SNAPSHOT must be fetched
+      id: killbill-oss-parent
+      run: |
+        REMOTE_SHA=$(git ls-remote --heads https://github.com/killbill/killbill-oss-parent.git ${GITHUB_REF##*/})
+        echo "killbill-oss-parent branch=${GITHUB_REF##*/} sha=${REMOTE_SHA}"
+        cd $GITHUB_WORKSPACE/killbill-platform
+        # Cannot use mvn help:evaluate unfortunately, as the project isn't buildable yet
+        PARENT_POM_VERSION=$(
+           awk '
+            /<dependenc/{exit}
+            /<parent>/{parent++};
+            /<version>/{
+              if (parent == 1) {
+                sub(/.*<version>/, "");
+                sub(/<.*/, "");
+                parent_version = $0;
+              }
+            }
+            /<\/parent>/{parent--};
+            END {
+              print parent_version
+            }' pom.xml
+        )
+        echo "killbill-oss-parent version=${PARENT_POM_VERSION}"
+        if [[ "$PARENT_POM_VERSION" =~ .*"-SNAPSHOT".* ]] && [ ! -z "$REMOTE_SHA" ]; then
+          echo "::set-output name=FETCH_SNAPSHOT::true"
+        else
+          echo "::set-output name=FETCH_SNAPSHOT::false"
+        fi
+    - name: Checkout killbill-oss-parent
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-oss-parent
+        ref: ${{ github.ref }}
+        path: killbill-oss-parent
+    - name: Build killbill-oss-parent
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-oss-parent
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-commons
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-commons
+        ref: ${{ github.ref }}
+        path: killbill-commons
+    - name: Build killbill-commons
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-commons
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-plugin-framework-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-plugin-framework-java
+        ref: ${{ github.ref }}
+        path: killbill-plugin-framework-java
+    - name: Build killbill-plugin-framework-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-plugin-framework-java
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        source-root: killbill-platform
+    - name: Build killbill-platform
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-platform
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+      with:
+        checkout_path: ${{ github.workspace }}/killbill-platform

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+0.40.8
+    Add support for JDK 11
+    Update to killbill-oss-parent 0.144.56
+
 0.40.7
     Update to killbill-oss-parent 0.144.50
 

--- a/base/src/main/java/org/killbill/billing/platform/jndi/JNDIManager.java
+++ b/base/src/main/java/org/killbill/billing/platform/jndi/JNDIManager.java
@@ -36,11 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.sun.jndi.rmi.registry.RegistryContextFactory;
 
 public class JNDIManager {
 
     private static final Logger logger = LoggerFactory.getLogger(JNDIManager.class);
+
+    private static final String REGISTRY_CONTEXT_FACTORY = "com.sun.jndi.rmi.registry.RegistryContextFactory";
 
     private final int port;
 
@@ -59,7 +60,7 @@ public class JNDIManager {
 
         // Set these properties globally, so individual plugins don't have to worry about it
         System.setProperty(Context.PROVIDER_URL, "rmi://127.0.0.1:" + port);
-        System.setProperty(Context.INITIAL_CONTEXT_FACTORY, RegistryContextFactory.class.getName());
+        System.setProperty(Context.INITIAL_CONTEXT_FACTORY, REGISTRY_CONTEXT_FACTORY);
     }
 
     public void export(final String name, final Object object) {
@@ -130,7 +131,7 @@ public class JNDIManager {
     private Context getContext() throws NamingException {
         final Hashtable<String, String> environment = new Hashtable<String, String>();
         environment.put(Context.PROVIDER_URL, "rmi://127.0.0.1:" + port);
-        environment.put(Context.INITIAL_CONTEXT_FACTORY, RegistryContextFactory.class.getName());
+        environment.put(Context.INITIAL_CONTEXT_FACTORY, REGISTRY_CONTEXT_FACTORY);
 
         return new InitialContext(environment);
     }

--- a/osgi-bundles/bundles/jruby/pom.xml
+++ b/osgi-bundles/bundles/jruby/pom.xml
@@ -166,9 +166,9 @@
             <artifactId>jruby-core</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>yecht</artifactId>
                     <!-- OSGI build error with YechtService which is in the default package -->
                     <groupId>org.jruby</groupId>
+                    <artifactId>yecht</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/osgi-bundles/defaultbundles/pom.xml
+++ b/osgi-bundles/defaultbundles/pom.xml
@@ -49,10 +49,10 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <appendAssemblyId>false</appendAssemblyId>
                             <tarLongFileMode>gnu</tarLongFileMode>

--- a/osgi-bundles/tests/beatrix/pom.xml
+++ b/osgi-bundles/tests/beatrix/pom.xml
@@ -89,10 +89,10 @@
                 <executions>
                     <execution>
                         <id>add-source</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>src/test/java</source>

--- a/osgi-bundles/tests/payment/pom.xml
+++ b/osgi-bundles/tests/payment/pom.xml
@@ -89,10 +89,10 @@
                 <executions>
                     <execution>
                         <id>add-source</id>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>src/test/java</source>

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -151,6 +151,8 @@ public class DefaultOSGIService implements OSGIService {
         config.put("org.osgi.framework.system.packages.extra", systemExtraPackages.toString());
         config.put("felix.cache.rootdir", osgiConfig.getOSGIBundleRootDir());
         config.put("org.osgi.framework.storage", osgiConfig.getOSGIBundleCacheName());
+        // Use the ext class loader as parent so that bundles can load java.sql.* on JDK 11
+        config.put("org.osgi.framework.bundle.parent", "ext");
         return createAndInitFelixFrameworkWithSystemBundle(config);
     }
 

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -28,5 +28,5 @@
     <artifactId>killbill-platform-api</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-api</name>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -266,15 +266,15 @@
                 <executions>
                     <execution>
                         <id>copy</id>
-                        <phase>initialize</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <phase>initialize</phase>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar" />
-                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar" />
-                                <copy file="${basedir}/../osgi-bundles/bundles/jruby/target/killbill-platform-osgi-bundles-jruby-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-jruby.jar" />
+                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/bundles/jruby/target/killbill-platform-osgi-bundles-jruby-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-jruby.jar"/>
                             </tasks>
                         </configuration>
                     </execution>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -33,6 +33,13 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- 2.0.0-alpha1 is somehow pulled on JDK 11 -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -58,6 +65,13 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
+            <exclusions>
+                <!-- https://github.com/brettwooldridge/HikariCP/issues/1746 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.53-SNAPSHOT</version>
+        <version>0.144.56</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.40.8-SNAPSHOT</version>
@@ -55,8 +55,6 @@
     </issueManagement>
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
-        <killbill-base-plugin.version>4.2.13-SNAPSHOT</killbill-base-plugin.version>
-        <killbill-commons.version>0.24.15-SNAPSHOT</killbill-commons.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.50</version>
+        <version>0.144.53-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.40.8-SNAPSHOT</version>
@@ -55,6 +55,8 @@
     </issueManagement>
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
+        <killbill-base-plugin.version>4.2.13-SNAPSHOT</killbill-base-plugin.version>
+        <killbill-commons.version>0.24.15-SNAPSHOT</killbill-commons.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -140,6 +140,13 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <!-- https://github.com/brettwooldridge/HikariCP/issues/1746 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -82,52 +82,52 @@
             <!-- We're not quite yet ready to upgrade these... -->
             <exclusions>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-joda</artifactId>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-guava</artifactId>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-jsr310</artifactId>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-jdk8</artifactId>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jackson-module-afterburner</artifactId>
                     <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-afterburner</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
-                    <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
-                    <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
-                    <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-io</artifactId>
-                    <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-server</artifactId>
-                    <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-http</artifactId>
-                    <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>jetty-util</artifactId>
                     <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/service-registry/pom.xml
+++ b/service-registry/pom.xml
@@ -50,18 +50,18 @@
             <version>1.8.7</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>annotations</artifactId>
                     <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>servlet-api</artifactId>
                     <!-- Use javax.servlet:javax.servlet-api instead -->
                     <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>commons-logging</artifactId>
                     <!-- Use jcl-over-slf4j instead -->
                     <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
The main change is the use of the `ext` class loader as the parent, to make `java.sql` visible to bundles.

/cc @andrenpaes 