### PR TITLE
add new properties for killbill-api.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     </issueManagement>
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
+        <killbill-api.version>0.54.0-0010563-SNAPSHOT</killbill-api.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
I found that we can exlude it in main killbill repository, but they're everywhere, so maybe add the version here (although for temporary) will be easier.