### PR TITLE
prometheus: initial integration

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -31,6 +31,8 @@
     <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/logger/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/metrics/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/metrics/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/prometheus/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/prometheus/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/osgi-bundles/bundles/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/osgi-bundles/defaultbundles" charset="UTF-8" />

--- a/osgi-bundles/bundles/pom.xml
+++ b/osgi-bundles/bundles/pom.xml
@@ -35,6 +35,7 @@
         <module>eureka</module>
         <module>graphite</module>
         <module>influxdb</module>
+        <module>prometheus</module>
         <module>metrics</module>
     </modules>
     <properties>

--- a/osgi-bundles/bundles/prometheus/README.md
+++ b/osgi-bundles/bundles/prometheus/README.md
@@ -1,0 +1,7 @@
+# Prometheus bundle
+
+Metrics integration with Prometheus.
+
+## Testing
+
+Go to http://127.0.0.1:8080/plugins/killbill-prometheus.

--- a/osgi-bundles/bundles/prometheus/pom.xml
+++ b/osgi-bundles/bundles/prometheus/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2022 Equinix, Inc
+  ~ Copyright 2014-2022 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.kill-bill.billing</groupId>
+        <artifactId>killbill-platform-osgi-bundles</artifactId>
+        <version>0.41.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>killbill-platform-osgi-bundles-prometheus</artifactId>
+    <packaging>bundle</packaging>
+    <name>killbill-platform-osgi-bundles-prometheus</name>
+    <properties>
+        <!-- io.prometheus libraries have duplicated classes... -->
+        <check.skip-duplicate-finder>true</check.skip-duplicate-finder>
+        <osgi.private>org.killbill.billing.osgi.bundles.prometheus.*</osgi.private>
+        <prometheus.version>0.15.0</prometheus.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-platform-osgi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.billing</groupId>
+            <artifactId>killbill-platform-osgi-bundles-lib-killbill</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <!-- Required for org.osgi.service.log.LogService -->
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/Activator.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/Activator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.prometheus;
+
+import java.util.Hashtable;
+
+import javax.servlet.Servlet;
+
+import org.killbill.billing.osgi.api.OSGIPluginProperties;
+import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
+import org.killbill.commons.metrics.api.MetricRegistry;
+import org.osgi.framework.BundleContext;
+
+public class Activator extends KillbillActivatorBase {
+
+    public static final String BUNDLE_NAME = "killbill-prometheus";
+
+    @Override
+    public void start(final BundleContext context) throws Exception {
+        super.start(context);
+
+        // Feed Kill Bill metrics to a custom Prometheus Collector
+        final MetricRegistry kbRegistry = this.metricRegistry.getMetricRegistry();
+        final KillBillCollector killBillCollector = new KillBillCollector(kbRegistry);
+        killBillCollector.register();
+
+        // Register a servlet to expose metrics, to be read by the Prometheus server.
+        registerServlet(context, new KillBillMetricsServlet());
+    }
+
+    private void registerServlet(final BundleContext context, final Servlet servlet) {
+        final Hashtable<String, String> props = new Hashtable<>();
+        props.put(OSGIPluginProperties.PLUGIN_NAME_PROP, BUNDLE_NAME);
+        registrar.registerService(context, Servlet.class, servlet, props);
+    }
+}

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillCollector.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillCollector.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.prometheus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import org.killbill.commons.metrics.api.Counter;
+import org.killbill.commons.metrics.api.Gauge;
+import org.killbill.commons.metrics.api.Histogram;
+import org.killbill.commons.metrics.api.Meter;
+import org.killbill.commons.metrics.api.Metric;
+import org.killbill.commons.metrics.api.MetricRegistry;
+import org.killbill.commons.metrics.api.Snapshot;
+import org.killbill.commons.metrics.api.Timer;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.prometheus.client.Collector;
+
+// Inspired from io.prometheus.client.dropwizard.DropwizardExports (Apache-2.0 License)
+public class KillBillCollector extends Collector {
+
+    private final MetricRegistry registry;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public KillBillCollector(final MetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        final Map<String, MetricFamilySamples> mfSamplesMap = new HashMap<>();
+
+        for (final SortedMap.Entry<String, Gauge<?>> entry : registry.getGauges().entrySet()) {
+            addToMap(mfSamplesMap, fromGauge(entry.getKey(), entry.getValue()));
+        }
+        for (final SortedMap.Entry<String, Counter> entry : registry.getCounters().entrySet()) {
+            addToMap(mfSamplesMap, fromCounter(entry.getKey(), entry.getValue()));
+        }
+        for (final SortedMap.Entry<String, Histogram> entry : registry.getHistograms().entrySet()) {
+            addToMap(mfSamplesMap, fromHistogram(entry.getKey(), entry.getValue()));
+        }
+        for (final SortedMap.Entry<String, Timer> entry : registry.getTimers().entrySet()) {
+            addToMap(mfSamplesMap, fromTimer(entry.getKey(), entry.getValue()));
+        }
+        for (final SortedMap.Entry<String, Meter> entry : registry.getMeters().entrySet()) {
+            addToMap(mfSamplesMap, fromMeter(entry.getKey(), entry.getValue()));
+        }
+        return new ArrayList<>(mfSamplesMap.values());
+    }
+
+    private MetricFamilySamples fromCounter(final String name, final Counter counter) {
+        final MetricFamilySamples.Sample sample = createSample(name, "", new ArrayList<>(), new ArrayList<>(),
+                                                               Long.valueOf(counter.getCount()).doubleValue());
+        return new MetricFamilySamples(sample.name, Type.GAUGE, getHelpMessage(name, counter), List.of(sample));
+    }
+
+    private String getHelpMessage(final String metricName, final Metric metric) {
+        return String.format("Generated from Kill Bill metric import (metric=%s, type=%s)",
+                             metricName, metric.getClass().getName());
+    }
+
+    private MetricFamilySamples fromGauge(final String name, final Gauge<?> gauge) {
+        final Object obj = gauge.getValue();
+        final double value;
+        if (obj instanceof Number) {
+            value = ((Number) obj).doubleValue();
+        } else if (obj instanceof Boolean) {
+            value = ((Boolean) obj) ? 1 : 0;
+        } else {
+            return null;
+        }
+        final MetricFamilySamples.Sample sample = createSample(name, "",
+                                                               new ArrayList<>(),
+                                                               new ArrayList<>(),
+                                                               value);
+        return new MetricFamilySamples(sample.name, Type.GAUGE, getHelpMessage(name, gauge), List.of(sample));
+    }
+
+    private MetricFamilySamples fromSnapshotAndCount(final String name,
+                                                     final Snapshot snapshot,
+                                                     final long count,
+                                                     final double factor,
+                                                     final String helpMessage) {
+        final List<MetricFamilySamples.Sample> samples = Arrays.asList(
+                createSample(name, "", List.of("quantile"), List.of("0.5"), snapshot.getMedian() * factor),
+                createSample(name, "", List.of("quantile"), List.of("0.75"), snapshot.get75thPercentile() * factor),
+                createSample(name, "", List.of("quantile"), List.of("0.95"), snapshot.get95thPercentile() * factor),
+                createSample(name, "", List.of("quantile"), List.of("0.98"), snapshot.get98thPercentile() * factor),
+                createSample(name, "", List.of("quantile"), List.of("0.99"), snapshot.get99thPercentile() * factor),
+                createSample(name, "", List.of("quantile"), List.of("0.999"), snapshot.get999thPercentile() * factor),
+                createSample(name, "_count", new ArrayList<>(), new ArrayList<>(), count)
+                                                                      );
+        return new MetricFamilySamples(samples.get(0).name, Type.SUMMARY, helpMessage, samples);
+    }
+
+    private MetricFamilySamples fromHistogram(final String name, final Histogram histogram) {
+        return fromSnapshotAndCount(name, histogram.getSnapshot(), histogram.getCount(), 1.0,
+                                    getHelpMessage(name, histogram));
+    }
+
+    private MetricFamilySamples fromTimer(final String name, final Timer timer) {
+        return fromSnapshotAndCount(name, timer.getSnapshot(), timer.getCount(),
+                                    1.0D / TimeUnit.SECONDS.toNanos(1L), getHelpMessage(name, timer));
+    }
+
+    private MetricFamilySamples fromMeter(final String name, final Meter meter) {
+        final MetricFamilySamples.Sample sample = createSample(name, "_total",
+                                                               new ArrayList<>(),
+                                                               new ArrayList<>(),
+                                                               meter.getCount());
+        return new MetricFamilySamples(sample.name, Type.COUNTER, getHelpMessage(name, meter),
+                                       List.of(sample));
+    }
+
+    private void addToMap(final Map<String, MetricFamilySamples> mfSamplesMap, final MetricFamilySamples newMfSamples) {
+        if (newMfSamples != null) {
+            final MetricFamilySamples currentMfSamples = mfSamplesMap.get(newMfSamples.name);
+            if (currentMfSamples == null) {
+                mfSamplesMap.put(newMfSamples.name, newMfSamples);
+            } else {
+                final List<MetricFamilySamples.Sample> samples = new ArrayList<>(currentMfSamples.samples);
+                samples.addAll(newMfSamples.samples);
+                mfSamplesMap.put(newMfSamples.name, new MetricFamilySamples(newMfSamples.name, currentMfSamples.type, currentMfSamples.help, samples));
+            }
+        }
+    }
+
+    public Collector.MetricFamilySamples.Sample createSample(final String name,
+                                                             final String nameSuffix,
+                                                             final List<String> additionalLabelNames,
+                                                             final List<String> additionalLabelValues,
+                                                             final double value) {
+        final String suffix = nameSuffix == null ? "" : nameSuffix;
+        final List<String> labelNames = additionalLabelNames == null ? Collections.<String>emptyList() : additionalLabelNames;
+        final List<String> labelValues = additionalLabelValues == null ? Collections.<String>emptyList() : additionalLabelValues;
+        return new Collector.MetricFamilySamples.Sample(
+                Collector.sanitizeMetricName(name + suffix),
+                new ArrayList<>(labelNames),
+                new ArrayList<>(labelValues),
+                value
+        );
+    }
+}

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillExporter.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillExporter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.prometheus;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Predicate;
+import io.prometheus.client.SampleNameFilter;
+import io.prometheus.client.exporter.common.TextFormat;
+
+// We cannot use io.prometheus.client.servlet.common.exporter.Exporter as it puts the Response in Writer mode
+// while Kill Bill expects it to be in Streaming mode
+public class KillBillExporter {
+
+    private final CollectorRegistry registry;
+    private final Predicate<String> sampleNameFilter;
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public KillBillExporter(final CollectorRegistry registry, final Predicate<String> sampleNameFilter) {
+        this.registry = registry;
+        this.sampleNameFilter = sampleNameFilter;
+    }
+
+    public void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        resp.setStatus(200);
+        final String contentType = TextFormat.chooseContentType(req.getHeader("Accept"));
+        resp.setContentType(contentType);
+
+        try (final Writer writer = new BufferedWriter(new OutputStreamWriter(resp.getOutputStream(), StandardCharsets.UTF_8))) {
+            final Predicate<String> filter = SampleNameFilter.restrictToNamesEqualTo(this.sampleNameFilter, parse(req));
+            if (filter == null) {
+                TextFormat.writeFormat(contentType, writer, this.registry.metricFamilySamples());
+            } else {
+                TextFormat.writeFormat(contentType, writer, this.registry.filteredMetricFamilySamples(filter));
+            }
+
+            writer.flush();
+        }
+    }
+
+    private Set<String> parse(final ServletRequest req) {
+        final String[] includedParam = req.getParameterValues("name[]");
+        return includedParam == null ? Collections.emptySet() : new HashSet(Arrays.asList(includedParam));
+    }
+}

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillMetricsServlet.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillMetricsServlet.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.prometheus;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.prometheus.client.CollectorRegistry;
+
+// We cannot use io.prometheus.client.exporter.MetricsServlet as the Exporter is private
+public class KillBillMetricsServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -5387012973467577781L;
+
+    private final transient KillBillExporter exporter;
+
+    public KillBillMetricsServlet() {
+        exporter = new KillBillExporter(CollectorRegistry.defaultRegistry, null);
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        exporter.doGet(req, resp);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        exporter.doGet(req, resp);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             </dependency>
             <dependency>
                 <groupId>org.kill-bill.billing</groupId>
+                <artifactId>killbill-platform-osgi-bundles-prometheus</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.kill-bill.billing</groupId>
                 <artifactId>killbill-platform-osgi-bundles-test-beatrix</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
OSGI bundle POC to expose Kill Bill Metrics to Prometheus.

By default, the endpoint is `/plugins/killbill-prometheus`. If this needs to be changed, this can easily be done via the Tomcat rewrite Valve.

I've verified that plugin specific metrics are exported as well. For instance, using the [Hello World](https://github.com/killbill/killbill-hello-world-java-plugin/pull/9) example:
```
# HELP hello_counter Generated from Kill Bill metric import (metric=hello_counter, type=org.killbill.commons.metrics.dropwizard.KillBillCodahaleCounter)
# TYPE hello_counter gauge
hello_counter 19.0
```
_Note: I'm not sure why it thinks it's a gauge and not a counter though_

I don't think we need an integration with Pushgateway too?

/cc @andrenpaes 