### PR TITLE
eureka: resolve commons-logging to 1.2

### DIFF
--- a/osgi-bundles/bundles/eureka/pom.xml
+++ b/osgi-bundles/bundles/eureka/pom.xml
@@ -38,6 +38,11 @@
                 <artifactId>commons-configuration</artifactId>
                 <version>1.10</version>
             </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
The basepom `dependency-versions-check-maven-plugin` now detects:

```
Error:  commons-logging:commons-logging: 1.1.1 (transitive) - scope: compile - strategy: default
       1.2 expected by com.netflix.eureka:eureka-client
```