### PR TITLE
1615 remove guava part 1

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -92,6 +88,10 @@
             <artifactId>killbill-queue</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>

--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -21,9 +21,11 @@ package org.killbill.billing.platform.config;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -32,14 +34,12 @@ import javax.annotation.Nullable;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
 import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.commons.utils.Strings;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
 import org.killbill.xmlloader.UriAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGIConfigProperties {
@@ -79,7 +79,7 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
     }
 
     public DefaultKillbillConfigSource(@Nullable final String file) throws URISyntaxException, IOException {
-        this(file, ImmutableMap.<String, String>of());
+        this(file, Collections.emptyMap());
     }
 
     public DefaultKillbillConfigSource(@Nullable final String file, final Map<String, String> extraDefaultProperties) throws URISyntaxException, IOException {
@@ -255,9 +255,7 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
             final String key = (String) keys.nextElement();
             final String value = (String) properties.get(key);
             final Optional<String> decryptableValue = decryptableValue(value);
-            if (decryptableValue.isPresent()) {
-                properties.setProperty(key, encryptor.decrypt(decryptableValue.get()));
-            }
+            decryptableValue.ifPresent(s -> properties.setProperty(key, encryptor.decrypt(s)));
         }
     }
 
@@ -287,7 +285,7 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
 
     private Optional<String> decryptableValue(final String value) {
         if (value == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         final int start = value.indexOf(ENC_PREFIX);
@@ -297,6 +295,6 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
                 return Optional.of(value.substring(start + ENC_PREFIX.length(), end));
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/base/src/main/java/org/killbill/billing/platform/glue/NotificationQueueModule.java
+++ b/base/src/main/java/org/killbill/billing/platform/glue/NotificationQueueModule.java
@@ -19,13 +19,13 @@
 
 package org.killbill.billing.platform.glue;
 
+import java.util.Map;
+
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.notificationq.DefaultNotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueConfig;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.config.ConfigurationObjectFactory;
-
-import com.google.common.collect.ImmutableMap;
 
 public class NotificationQueueModule extends KillBillPlatformModuleBase {
 
@@ -45,7 +45,7 @@ public class NotificationQueueModule extends KillBillPlatformModuleBase {
 
     protected void configureNotificationQueueConfig() {
         final NotificationQueueConfig config = new ConfigurationObjectFactory(skifeConfigSource).buildWithReplacements(NotificationQueueConfig.class,
-                                                                                                                       ImmutableMap.<String, String>of("instanceName", "main"));
+                                                                                                                       Map.of("instanceName", "main"));
         bind(NotificationQueueConfig.class).toInstance(config);
     }
 }

--- a/base/src/main/java/org/killbill/billing/platform/jndi/DataSourceProxy.java
+++ b/base/src/main/java/org/killbill/billing/platform/jndi/DataSourceProxy.java
@@ -29,7 +29,8 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-import com.google.common.base.Preconditions;
+import org.killbill.commons.utils.Preconditions;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class DataSourceProxy implements DataSource {

--- a/base/src/main/java/org/killbill/billing/platform/jndi/JNDIManager.java
+++ b/base/src/main/java/org/killbill/billing/platform/jndi/JNDIManager.java
@@ -32,10 +32,9 @@ import javax.naming.NamingException;
 import javax.naming.Reference;
 import javax.naming.Referenceable;
 
+import org.killbill.commons.utils.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
 
 public class JNDIManager {
 

--- a/base/src/main/java/org/killbill/billing/platform/jndi/ReferenceableDataSourceSpyFactory.java
+++ b/base/src/main/java/org/killbill/billing/platform/jndi/ReferenceableDataSourceSpyFactory.java
@@ -27,7 +27,7 @@ import javax.naming.RefAddr;
 import javax.naming.Reference;
 import javax.naming.spi.ObjectFactory;
 
-import com.google.common.base.Preconditions;
+import org.killbill.commons.utils.Preconditions;
 
 public class ReferenceableDataSourceSpyFactory implements ObjectFactory {
 

--- a/base/src/main/java/org/killbill/commons/util/io/Files.java
+++ b/base/src/main/java/org/killbill/commons/util/io/Files.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.util.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.attribute.FileAttribute;
+
+// FIXME-1615 : Move this to killbill-utils
+public final class Files {
+
+    /**
+     * Do {@link java.nio.file.Files#createTempDirectory(String, FileAttribute[])} with {@link System#currentTimeMillis()}
+     * as name.
+     */
+    public static File createTempDirectory() {
+        try {
+            return java.nio.file.Files.createTempDirectory(String.valueOf(System.currentTimeMillis())).toFile();
+        } catch (final IOException e) {
+            throw new RuntimeException("Cannot create temp directory: " + e.getMessage());
+        }
+    }
+}

--- a/base/src/main/java/org/killbill/commons/util/package-info.java
+++ b/base/src/main/java/org/killbill/commons/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * FIXME-1615: Remove this package once classes under this package migrated to killbill-commons.
+ */
+package org.killbill.commons.util;

--- a/base/src/main/java/org/killbill/commons/util/reflect/AbstractInvocationHandler.java
+++ b/base/src/main/java/org/killbill/commons/util/reflect/AbstractInvocationHandler.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.commons.util.reflect;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * FIXME-1615 Move this to killbill-commons
+ *
+ * Verbatim copy of Guava's {@code com.google.common.reflect.AbstractInvocationHandler}.
+ *
+ * Abstract implementation of {@link InvocationHandler} that handles {@link Object#equals}, {@link
+ * Object#hashCode} and {@link Object#toString}. For example:
+ *
+ * <pre>
+ * class Unsupported extends AbstractInvocationHandler {
+ *   protected Object handleInvocation(Object proxy, Method method, Object[] args) {
+ *     throw new UnsupportedOperationException();
+ *   }
+ * }
+ *
+ * CharSequence unsupported = Reflection.newProxy(CharSequence.class, new Unsupported());
+ * </pre>
+ *
+ * @author Ben Yu
+ * @since 12.0
+ */
+public abstract class AbstractInvocationHandler implements InvocationHandler {
+
+    private static final Object[] NO_ARGS = {};
+
+    /**
+     * {@inheritDoc}
+     *
+     * <ul>
+     *   <li>{@code proxy.hashCode()} delegates to {@code com.google.common.reflect.AbstractInvocationHandler#hashCode}
+     *   <li>{@code proxy.toString()} delegates to {@code com.google.common.reflect.AbstractInvocationHandler#toString}
+     *   <li>{@code proxy.equals(argument)} returns true if:
+     *       <ul>
+     *         <li>{@code proxy} and {@code argument} are of the same type
+     *         <li>and {@code com.google.common.reflect.AbstractInvocationHandler#equals} returns true for the {@link
+     *             InvocationHandler} of {@code argument}
+     *       </ul>
+     *   <li>other method calls are dispatched to {@link #handleInvocation}.
+     * </ul>
+     */
+    @Override
+    @CheckForNull
+    public final Object invoke(final Object proxy, final Method method, @CheckForNull Object[] args) throws Throwable {
+        if (args == null) {
+            args = NO_ARGS;
+        }
+        if (args.length == 0 && "hashCode".equals(method.getName())) {
+            return hashCode();
+        }
+        if (args.length == 1
+            && "equals".equals(method.getName())
+            && method.getParameterTypes()[0] == Object.class) {
+            final Object arg = args[0];
+            if (arg == null) {
+                return false;
+            }
+            if (proxy == arg) {
+                return true;
+            }
+            return isProxyOfSameInterfaces(arg, proxy.getClass())
+                   && equals(Proxy.getInvocationHandler(arg));
+        }
+        if (args.length == 0 && "toString".equals(method.getName())) {
+            return toString();
+        }
+        return handleInvocation(proxy, method, args);
+    }
+
+    /**
+     * {@link #invoke} delegates to this method upon any method invocation on the proxy instance,
+     * except {@link Object#equals}, {@link Object#hashCode} and {@link Object#toString}. The result
+     * will be returned as the proxied method's return value.
+     *
+     * <p>Unlike {@link #invoke}, {@code args} will never be null. When the method has no parameter,
+     * an empty array is passed in.
+     */
+    @CheckForNull
+    protected abstract Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable;
+
+    /**
+     * By default delegates to {@link Object#equals} so instances are only equal if they are
+     * identical. {@code proxy.equals(argument)} returns true if:
+     *
+     * <ul>
+     *   <li>{@code proxy} and {@code argument} are of the same type
+     *   <li>and this method returns true for the {@link InvocationHandler} of {@code argument}
+     * </ul>
+     *
+     * <p>Subclasses can override this method to provide custom equality.
+     */
+    @Override
+    public boolean equals(@CheckForNull final Object obj) {
+        return super.equals(obj);
+    }
+
+    /**
+     * By default delegates to {@link Object#hashCode}. The dynamic proxies' {@code hashCode()} will
+     * delegate to this method. Subclasses can override this method to provide custom equality.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * By default delegates to {@link Object#toString}. The dynamic proxies' {@code toString()} will
+     * delegate to this method. Subclasses can override this method to provide custom string
+     * representation for the proxies.
+     */
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    private static boolean isProxyOfSameInterfaces(final Object arg, final Class<?> proxyClass) {
+        return proxyClass.isInstance(arg)
+               // Equal proxy instances should mostly be instance of proxyClass
+               // Under some edge cases (such as the proxy of JDK types serialized and then deserialized)
+               // the proxy type may not be the same.
+               // We first check isProxyClass() so that the common case of comparing with non-proxy objects
+               // is efficient.
+               || (Proxy.isProxyClass(arg.getClass())
+                   && Arrays.equals(arg.getClass().getInterfaces(), proxyClass.getInterfaces()));
+    }
+}

--- a/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
@@ -29,8 +29,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.killbill.billing.platform.config.DefaultKillbillConfigSource.ENVIRONMENT_VARIABLE_PREFIX;
 
 public class TestDefaultKillbillConfigSource {
@@ -80,10 +78,10 @@ public class TestDefaultKillbillConfigSource {
         final String unencryptedValue = "myPropertyValue";
         final String encryptedValue = encString(unencryptedValue);
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "false",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "false",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
         final DefaultKillbillConfigSource configSource = new DefaultKillbillConfigSource(properties);
 
@@ -96,10 +94,10 @@ public class TestDefaultKillbillConfigSource {
     public void testDecryptEmptyPassword() throws IOException, URISyntaxException {
         final String encryptedValue = encString("myPropertyValue");
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "true",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, "",
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "true",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, "",
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
         new DefaultKillbillConfigSource(properties);
     }
@@ -108,10 +106,10 @@ public class TestDefaultKillbillConfigSource {
     public void testDecryptEmptyAlgorithm() throws IOException, URISyntaxException {
         final String encryptedValue = encString("myPropertyValue");
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "true",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, "");
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "true",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, "");
 
         new DefaultKillbillConfigSource(properties);
     }
@@ -120,10 +118,10 @@ public class TestDefaultKillbillConfigSource {
     public void testDecryptInvalidJasyptString() throws IOException, URISyntaxException {
         final String encryptedValue = "ENC(notAValidEncryptedString!)";
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "true",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "true",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
         new DefaultKillbillConfigSource(properties);
     }
@@ -132,10 +130,10 @@ public class TestDefaultKillbillConfigSource {
     public void testDecryptEmptyJasyptString() throws IOException, URISyntaxException {
         final String encryptedValue = "ENC()";
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "true",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "true",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
         new DefaultKillbillConfigSource(properties);
     }
@@ -147,11 +145,11 @@ public class TestDefaultKillbillConfigSource {
         final String unencryptedValue2 = "myOtherPropertyValue";
         final String encryptedValue2 = encString(unencryptedValue2);
 
-        final Map<String, String> properties = ImmutableMap.of(ENABLE_JASYPT_PROPERTY, "true",
-                                                               ENCRYPTED_PROPERTY_1, encryptedValue1,
-                                                               ENCRYPTED_PROPERTY_2, encryptedValue2,
-                                                               JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
-                                                               JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
+        final Map<String, String> properties = Map.of(ENABLE_JASYPT_PROPERTY, "true",
+                                                      ENCRYPTED_PROPERTY_1, encryptedValue1,
+                                                      ENCRYPTED_PROPERTY_2, encryptedValue2,
+                                                      JASYPT_ENCRYPTOR_PASSWORD_PROPERTY, JASYPT_PASSWORD,
+                                                      JASYPT_ENCRYPTOR_ALGORITHM_PROPERTY, JASYPT_ALGORITHM);
 
         final DefaultKillbillConfigSource configSource = new DefaultKillbillConfigSource(properties);
 

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -99,6 +95,10 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-queue</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -97,10 +97,6 @@
             <artifactId>killbill-queue</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.kill-bill.commons</groupId>
-            <artifactId>killbill-utils</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/DefaultLifecycle.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/DefaultLifecycle.java
@@ -20,9 +20,12 @@
 package org.killbill.billing.lifecycle;
 
 import java.lang.reflect.Method;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -37,12 +40,6 @@ import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Supplier;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SortedSetMultimap;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -51,30 +48,27 @@ import com.google.inject.ProvisionException;
 public class DefaultLifecycle implements Lifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultLifecycle.class);
-    private final SortedSetMultimap<LifecycleLevel, LifecycleHandler<? extends KillbillService>> handlersByLevel;
+
+    // FIXME-1615: This was SortedSetMultimap<LifecycleLevel, LifecycleHandler<? extends KillbillService>> handlersByLevel
+    //   is it worth it to refactor org.killbill.commons.utils.collect.MultiValueMap just for this?
+    private final Map<LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> handlersByLevel;
 
     @Inject
     public DefaultLifecycle(final Injector injector) {
         this();
-        final ServiceFinder<KillbillService> serviceFinder = new ServiceFinder<KillbillService>(DefaultLifecycle.class.getClassLoader(), KillbillService.class.getName());
+        final ServiceFinder<KillbillService> serviceFinder = new ServiceFinder<>(DefaultLifecycle.class.getClassLoader(), KillbillService.class.getName());
         init(serviceFinder, injector);
     }
 
     // For testing
-    public DefaultLifecycle(final Set<? extends KillbillService> services) {
+    public DefaultLifecycle(final Iterable<? extends KillbillService> services) {
         this();
         init(services);
     }
 
 
     private DefaultLifecycle() {
-        this.handlersByLevel = Multimaps.newSortedSetMultimap(new ConcurrentHashMap<LifecycleHandlerType.LifecycleLevel, Collection<LifecycleHandler<? extends KillbillService>>>(),
-                                                              new Supplier<SortedSet<LifecycleHandler<? extends KillbillService>>>() {
-                                                                  @Override
-                                                                  public SortedSet<LifecycleHandler<? extends KillbillService>> get() {
-                                                                      return new TreeSet<LifecycleHandler<? extends KillbillService>>();
-                                                                  }
-                                                              });
+        this.handlersByLevel = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -98,7 +92,7 @@ public class DefaultLifecycle implements Lifecycle {
     }
 
     private Set<? extends KillbillService> findServices(final Set<Class<? extends KillbillService>> services, final Injector injector) {
-        final Set<KillbillService> result = new HashSet<KillbillService>();
+        final Set<KillbillService> result = new HashSet<>();
         for (final Class<? extends KillbillService> cur : services) {
             log.debug("Found service {}", cur.getName());
             try {
@@ -129,9 +123,16 @@ public class DefaultLifecycle implements Lifecycle {
         init(services);
     }
 
-    private void init(final Set<? extends KillbillService> services) {
+    private void init(final Iterable<? extends KillbillService> services) {
         for (final KillbillService service : services) {
-            handlersByLevel.putAll(findAllHandlers(service));
+            final Map<LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> values = findAllHandlers(service);
+            for (final Entry<LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> entry : values.entrySet()) {
+                if (handlersByLevel.get(entry.getKey()) != null) {
+                    handlersByLevel.get(entry.getKey()).addAll(entry.getValue());
+                } else {
+                    handlersByLevel.put(entry.getKey(), entry.getValue());
+                }
+            }
         }
     }
 
@@ -144,7 +145,7 @@ public class DefaultLifecycle implements Lifecycle {
 
     private void doFireStage(final LifecycleHandlerType.LifecycleLevel level) {
         log.info("Killbill lifecycle firing stage {}", level);
-        final Set<LifecycleHandler<? extends KillbillService>> handlers = handlersByLevel.get(level);
+        final Set<LifecycleHandler<? extends KillbillService>> handlers = handlersByLevel.getOrDefault(level, new TreeSet<>());
         for (final LifecycleHandler<? extends KillbillService> cur : handlers) {
 
             try {
@@ -168,21 +169,27 @@ public class DefaultLifecycle implements Lifecycle {
         }
     }
 
-    private Multimap<LifecycleHandlerType.LifecycleLevel, LifecycleHandler<? extends KillbillService>> findAllHandlers(final KillbillService service) {
-        final Multimap<LifecycleHandlerType.LifecycleLevel, LifecycleHandler<? extends KillbillService>> methodsInService = HashMultimap.create();
+    private Map<LifecycleHandlerType.LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> findAllHandlers(final KillbillService service) {
+        final Map<LifecycleHandlerType.LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> methodsInService = new HashMap<>();
         final Class<? extends KillbillService> clazz = service.getClass();
         for (final Method method : clazz.getMethods()) {
             final LifecycleHandlerType annotation = method.getAnnotation(LifecycleHandlerType.class);
             if (annotation != null) {
                 final LifecycleHandlerType.LifecycleLevel level = annotation.value();
-                final LifecycleHandler<? extends KillbillService> handler = new LifecycleHandler<KillbillService>(service, method);
-                methodsInService.put(level, handler);
+                final LifecycleHandler<? extends KillbillService> handler = new LifecycleHandler<>(service, method);
+                if (methodsInService.get(level) != null) {
+                    methodsInService.get(level).add(handler);
+                } else {
+                    final SortedSet<LifecycleHandler<? extends KillbillService>> handlers = new TreeSet<>();
+                    handlers.add(handler);
+                    methodsInService.put(level, handlers);
+                }
             }
         }
         return methodsInService;
     }
 
-    static final class LifecycleHandler<T extends KillbillService> implements Comparable<LifecycleHandler> {
+    static final class LifecycleHandler<T extends KillbillService> implements Comparable<LifecycleHandler<?>> {
 
         private final T target;
         private final Method method;
@@ -210,13 +217,13 @@ public class DefaultLifecycle implements Lifecycle {
                 return false;
             }
             final LifecycleHandler<?> that = (LifecycleHandler<?>) o;
-            return Objects.equal(target, that.target) &&
-                   Objects.equal(method, that.method);
+            return Objects.equals(target, that.target) &&
+                   Objects.equals(method, that.method);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(target, method);
+            return Objects.hash(target, method);
         }
 
         @Override
@@ -231,7 +238,7 @@ public class DefaultLifecycle implements Lifecycle {
         }
     }
 
-    SortedSetMultimap<LifecycleLevel, LifecycleHandler<? extends KillbillService>> getHandlersByLevel() {
+    Map<LifecycleLevel, SortedSet<LifecycleHandler<? extends KillbillService>>> getHandlersByLevel() {
         return handlersByLevel;
     }
 }

--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/ExternalPersistentBusConfig.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/bus/ExternalPersistentBusConfig.java
@@ -19,14 +19,14 @@
 
 package org.killbill.billing.lifecycle.bus;
 
+import java.util.Map;
+
 import org.killbill.bus.api.PersistentBusConfig;
 import org.skife.config.ConfigSource;
 import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.TimeSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableMap;
 
 // Hack to make sure the external and internal buses don't share the same tables names.
 // See discussion https://groups.google.com/forum/#!msg/killbilling-users/x3o1-EjR3V0/ZJ-PJYFM_M0J
@@ -49,9 +49,9 @@ public class ExternalPersistentBusConfig extends PersistentBusConfig {
     public ExternalPersistentBusConfig(final ConfigSource configSource) {
         // See org.killbill.billing.util.glue.BusModule
         internalPersistentBusConfig = new ConfigurationObjectFactory(configSource).buildWithReplacements(PersistentBusConfig.class,
-                                                                                                         ImmutableMap.<String, String>of("instanceName", MAIN_BUS_NAME));
+                                                                                                         Map.of("instanceName", MAIN_BUS_NAME));
         externalPersistentBusConfig = new ConfigurationObjectFactory(configSource).buildWithReplacements(PersistentBusConfig.class,
-                                                                                                         ImmutableMap.<String, String>of("instanceName", EXTERNAL_BUS_NAME));
+                                                                                                         Map.of("instanceName", EXTERNAL_BUS_NAME));
     }
 
     @Override

--- a/lifecycle/src/main/java/org/killbill/billing/lifecycle/glue/BusModule.java
+++ b/lifecycle/src/main/java/org/killbill/billing/lifecycle/glue/BusModule.java
@@ -19,6 +19,8 @@
 
 package org.killbill.billing.lifecycle.glue;
 
+import java.util.Map;
+
 import org.killbill.billing.lifecycle.api.BusService;
 import org.killbill.billing.lifecycle.api.ExternalBusService;
 import org.killbill.billing.lifecycle.bus.DefaultBusService;
@@ -31,7 +33,6 @@ import org.killbill.bus.api.PersistentBusConfig;
 import org.skife.config.ConfigSource;
 import org.skife.config.ConfigurationObjectFactory;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
@@ -60,7 +61,7 @@ public class BusModule extends AbstractModule {
 
         final SkifePersistentBusConfigSource skifePersistentBusConfigSource = new SkifePersistentBusConfigSource();
         final PersistentBusConfig busConfig = new ConfigurationObjectFactory(skifePersistentBusConfigSource).buildWithReplacements(PersistentBusConfig.class,
-                                                                                                                                   ImmutableMap.<String, String>of("instanceName", isExternal ? ExternalPersistentBusConfig.EXTERNAL_BUS_NAME : ExternalPersistentBusConfig.MAIN_BUS_NAME));
+                                                                                                                                   Map.of("instanceName", isExternal ? ExternalPersistentBusConfig.EXTERNAL_BUS_NAME : ExternalPersistentBusConfig.MAIN_BUS_NAME));
 
         if (isExternal) {
             bind(ExternalBusService.class).to(DefaultExternalBusService.class).asEagerSingleton();

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -66,10 +66,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -189,6 +185,10 @@
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-queue</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -37,8 +38,6 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class BundleRegistry {
@@ -125,12 +124,9 @@ public class BundleRegistry {
     }
 
     public Iterable<BundleWithMetadata> getPureOSGIBundles() {
-        return Iterables.filter(registry.values(), new Predicate<BundleWithMetadata>() {
-            @Override
-            public boolean apply(final BundleWithMetadata input) {
-                return input != null && input.getConfig() == null;
-            }
-        });
+        return registry.values().stream()
+                .filter(input -> input != null && input.getConfig() == null)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     public BundleWithMetadata getBundle(final String pluginName) {

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -41,7 +41,6 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("EI_EXPOSE_REP2")
@@ -168,7 +167,7 @@ public class DefaultOSGIService implements OSGIService {
         // Note! Think twice before adding a bundle here as it will run inside the System bundle. This means the bundle
         // callcontext that the bundle will see is the System bundle one, which will break e.g. resources lookup
         felixConfig.put(FelixConstants.SYSTEMBUNDLE_ACTIVATORS_PROP,
-                        ImmutableList.<BundleActivator>of(killbillActivator));
+                        List.<BundleActivator>of(killbillActivator));
 
         final Framework felix = new Felix(felixConfig);
         felix.init();

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
@@ -33,6 +33,8 @@ import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
+import org.killbill.commons.eventbus.AllowConcurrentEvents;
+import org.killbill.commons.eventbus.Subscribe;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.killbill.queue.QueueObjectMapper;
@@ -52,8 +54,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.eventbus.AllowConcurrentEvents;
-import com.google.common.eventbus.Subscribe;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 // Needs to be injected for the lifecycle logic

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
@@ -32,7 +32,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
-import com.google.common.collect.ImmutableMap;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class OSGIAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
@@ -90,7 +90,7 @@ public class OSGIAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private static final class RootBundleLogbackServiceReference implements ServiceReference {
 
         // MAGIC - do not change (see KillbillLogWriter)
-        private static final Map<String, String> SERVICE_KEYS = ImmutableMap.<String, String>of("KILL_BILL_ROOT_LOGGING", "true");
+        private static final Map<String, String> SERVICE_KEYS = Map.of("KILL_BILL_ROOT_LOGGING", "true");
 
         private final Bundle bundle;
 

--- a/osgi/src/main/java/org/killbill/billing/osgi/PureOSGIBundleFinder.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/PureOSGIBundleFinder.java
@@ -21,6 +21,7 @@ package org.killbill.billing.osgi;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +33,6 @@ import org.killbill.billing.osgi.config.OSGIConfig;
 import org.killbill.billing.osgi.pluginconf.PluginConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableList;
 
 @Singleton
 public class PureOSGIBundleFinder {
@@ -57,15 +56,15 @@ public class PureOSGIBundleFinder {
         final File rootDir = new File(rootDirPath);
         if (!rootDir.exists() || !rootDir.isDirectory()) {
             logger.warn("Configuration root dir {} is not a valid directory", rootDirPath);
-            return ImmutableList.<String>of();
+            return Collections.emptyList();
         }
 
         final File[] files = rootDir.listFiles();
         if (files == null) {
-            return ImmutableList.<String>of();
+            return Collections.emptyList();
         }
 
-        final List<String> bundles = new ArrayList<String>();
+        final List<String> bundles = new ArrayList<>();
         for (final File bundleJar : files) {
             if (bundleJar.isFile()) {
                 bundles.add(bundleJar.getAbsolutePath());

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/OSGIServlet.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/OSGIServlet.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
 
 @Singleton
 public class OSGIServlet extends HttpServlet {
@@ -40,7 +40,7 @@ public class OSGIServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
     @VisibleForTesting
-    final Vector<Servlet> initializedServlets = new Vector<Servlet>();
+    final Vector<Servlet> initializedServlets = new Vector<>();
     private final Object servletsMonitor = new Object();
 
     @Inject

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/StaticServlet.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/StaticServlet.java
@@ -20,6 +20,7 @@
 package org.killbill.billing.osgi.http;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 
 import javax.servlet.RequestDispatcher;
@@ -30,8 +31,6 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.http.HttpContext;
-
-import com.google.common.io.Resources;
 
 // Simple servlet to serve OSGI resources
 public class StaticServlet extends HttpServlet {
@@ -46,9 +45,11 @@ public class StaticServlet extends HttpServlet {
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         final URL url = findResourceURL(req);
         if (url != null) {
-            Resources.copy(url, resp.getOutputStream());
-            resp.setStatus(200);
-            return;
+            try (final InputStream is = url.openStream()) {
+                is.transferTo(resp.getOutputStream());
+                resp.setStatus(200);
+                return;
+            }
         }
 
         // If we can't find it, the container might

--- a/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestDefaultPluginConfig.java
+++ b/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestDefaultPluginConfig.java
@@ -19,16 +19,17 @@
 
 package org.killbill.billing.osgi.pluginconf;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
 import org.killbill.billing.osgi.api.config.PluginConfig;
+import org.killbill.commons.util.io.Files;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.io.Files;
 
 // Verify ordering from PluginFinder#loadPluginsIfRequired
 public class TestDefaultPluginConfig {
@@ -57,7 +58,7 @@ public class TestDefaultPluginConfig {
     private static final class DummyJavaConfig extends DefaultPluginJavaConfig {
 
         public DummyJavaConfig(final String version, final boolean isSelectedForStart) throws PluginConfigException {
-            super("stripe", "killbill-stripe", version, Files.createTempDir(), new Properties(), isSelectedForStart, true);
+            super("stripe", "killbill-stripe", version, Files.createTempDirectory(), new Properties(), isSelectedForStart, true);
         }
 
         @Override

--- a/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
+++ b/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
@@ -27,10 +27,10 @@ import javax.annotation.Nullable;
 
 import org.killbill.billing.osgi.api.config.PluginJavaConfig;
 import org.killbill.billing.osgi.config.OSGIConfig;
+import org.killbill.commons.util.io.Files;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.io.Files;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static org.testng.Assert.assertEquals;
@@ -49,7 +49,7 @@ public class TestPluginFinder {
 
     @BeforeMethod(groups = "fast")
     public void beforeMethod() {
-        rootInstallationDir = Files.createTempDir();
+        rootInstallationDir = Files.createTempDirectory();
 
         final OSGIConfig osgiConfig = createOSGIConfig();
         pluginFinder = new PluginFinder(osgiConfig);

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <!-- Bug with maven-deploy-plugin -->
         <deploy.deploy-at-end>false</deploy.deploy-at-end>
+        <killbill-commons.version>0.25.1-02e249b-SNAPSHOT</killbill-commons.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
1. Affected modules: `killbill-platform-base`, `killbill-platform-lifecycle`, `killbill-platform-osgi`.
2. There's temporary util classes that will be put back to `killbill-commons` later in `killbill-platform-base`
3. There's reason why `killbill-platform` pom.xml need to declare killbill-commons version
   - not all `killbill-utils` module available in every version of killbill-commons parent.
   - we can use `killbill-oss-parent` version `0.145.3-bb9d252-SNAPSHOT`: The same version that `killbill` repository currently use  (at least in my current branch). However, I got failed test (see stacktrace in comment). My first thought, it is because eventbus migration that not completed yet. Adding `<killbill-commons.version>0.25.1-02e249b-SNAPSHOT</killbill-commons.version>` fix the problem.