### PR TITLE
1615 add missing nullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-c270082-SNAPSHOT</version>
+        <version>0.145.3-17b5048-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.41.0-SNAPSHOT</version>
@@ -56,7 +56,6 @@
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <!-- Bug with maven-deploy-plugin -->
         <deploy.deploy-at-end>false</deploy.deploy-at-end>
-        <killbill-commons.version>0.25.1-32bcd54-SNAPSHOT</killbill-commons.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
+++ b/server/src/main/java/org/killbill/billing/server/healthchecks/KillbillHealthcheck.java
@@ -58,7 +58,7 @@ public class KillbillHealthcheck implements HealthCheck {
     }
 
     @Inject
-    public void setPluginServiceDiscoveryRegistries(final OSGIServiceRegistration<ServiceDiscoveryRegistry> pluginServiceDiscoveryRegistries) {
+    public void setPluginServiceDiscoveryRegistries(@Nullable final OSGIServiceRegistration<ServiceDiscoveryRegistry> pluginServiceDiscoveryRegistries) {
         this.pluginServiceDiscoveryRegistries = pluginServiceDiscoveryRegistries;
     }
 


### PR DESCRIPTION
an attempt to fix problem in `killbill` repository:

- add `@Nullable` to `KillbillHealthcheck.setPluginServiceDiscoveryRegistries()`
- update `killbill-oss-parent` version.