### PR TITLE
Corrected the RO DAO property

### DIFF
--- a/server/src/main/java/org/killbill/billing/server/modules/MainRoDaoConfig.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/MainRoDaoConfig.java
@@ -30,7 +30,7 @@ import org.skife.config.TimeSpan;
 
 public interface MainRoDaoConfig extends DaoConfig {
 
-    static final String DATA_SOURCE_PROP_PREFIX = "org.killbill.billing.main-ro.dao.";
+    static final String DATA_SOURCE_PROP_PREFIX = "org.killbill.billing.main.ro.dao.";
 
     @Description("Whether the read-only datasource is enabled")
     @Config(DATA_SOURCE_PROP_PREFIX + "enabled")

--- a/server/src/main/java/org/killbill/billing/server/modules/MainRoDaoConfig.java
+++ b/server/src/main/java/org/killbill/billing/server/modules/MainRoDaoConfig.java
@@ -30,7 +30,7 @@ import org.skife.config.TimeSpan;
 
 public interface MainRoDaoConfig extends DaoConfig {
 
-    static final String DATA_SOURCE_PROP_PREFIX = "org.killbill.billing.main.ro.dao.";
+    String DATA_SOURCE_PROP_PREFIX = "org.killbill.billing.main.ro.dao.";
 
     @Description("Whether the read-only datasource is enabled")
     @Config(DATA_SOURCE_PROP_PREFIX + "enabled")


### PR DESCRIPTION
* The dash in org.killbill.billing.main-ro.dao. isn't k8s friendly, as we cannot easily support environment variables with dashes so renamed it to org.killbill.billing.main.ro.dao.
* Removed the redundant static final modifier from the interface field.