### PR TITLE
Oss 619 step 2 update killbill platform

### DIFF
--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -80,9 +80,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>testing-postgresql-server</artifactId>
-            <!-- Technically, test-runtime -->
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-17b5048-SNAPSHOT</version>
+        <version>0.145.3-dba4e8d-SNAPSHOT</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.41.0-SNAPSHOT</version>


### PR DESCRIPTION
- Use killbill-platform local SNAPSHOT in killbill, and test them: passed
- Use killbill-platfrom local SNAPSHOT in killbill-stripe/braintree-plugin, update jooq version, and test them : passed