### PR TITLE
platform 120 - update osgi log to 1.5.0

### DIFF
--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -85,7 +86,7 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
             this.properties = loadPropertiesFromFileOrSystemProperties();
         } else {
             this.properties = new Properties();
-            this.properties.load(UriAccessor.accessUri(this.getClass().getResource(file).toURI()));
+            this.properties.load(UriAccessor.accessUri(Objects.requireNonNull(this.getClass().getResource(file)).toURI()));
         }
 
         for (final Entry<String, String> entry : extraDefaultProperties.entrySet()) {
@@ -112,7 +113,9 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
 
     @Override
     public Properties getProperties() {
-        return new Properties(properties);
+        final Properties result = new Properties();
+        result.putAll(properties);
+        return result;
     }
 
     private Properties loadPropertiesFromFileOrSystemProperties() {

--- a/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
@@ -21,10 +21,12 @@ package org.killbill.billing.platform.config;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
+import org.killbill.billing.osgi.api.OSGIConfigProperties;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -51,6 +53,19 @@ public class TestDefaultKillbillConfigSource {
         System.clearProperty(JASYPT_ALGORITHM);
         System.clearProperty(ENCRYPTED_PROPERTY_1);
         System.clearProperty(ENCRYPTED_PROPERTY_2);
+    }
+
+    @Test(groups = "fast")
+    public void testGetProperties() throws URISyntaxException, IOException {
+        final Map<String, String> configuration = new HashMap<>();
+        configuration.put("1", "A");
+        configuration.put("2", "B");
+
+        final OSGIConfigProperties configSource = new DefaultKillbillConfigSource(null, configuration);
+
+        Assert.assertNotNull(configSource.getProperties());
+        Assert.assertNotEquals(configSource.getProperties().size(), 0);
+        Assert.assertEquals(configSource.getProperties().getProperty("1"), "A");
     }
 
     @Test(groups = "fast")

--- a/osgi-bundles/bundles/logger/pom.xml
+++ b/osgi-bundles/bundles/logger/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>killbill-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.log</artifactId>
             <scope>provided</scope>
@@ -112,6 +117,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/Activator.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/Activator.java
@@ -31,26 +31,27 @@ import org.killbill.billing.plugin.core.resources.jooby.PluginApp;
 import org.killbill.billing.plugin.core.resources.jooby.PluginAppBuilder;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.log.LogService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.osgi.service.log.LoggerFactory;
 
 public class Activator extends KillbillActivatorBase {
-
-    private static final Logger logger = LoggerFactory.getLogger(Activator.class);
 
     public static final String PLUGIN_NAME = "killbill-osgi-logger";
 
     private LogEntriesManager logEntriesManager;
     private LogsSseHandler logsSseHandler;
     private KillbillLogWriter killbillLogListener;
+    private KillbillLoggerFactory loggerFactory;
 
     @Override
     public void start(final BundleContext context) throws Exception {
+        loggerFactory = new KillbillLoggerFactory(context.getBundle());
         logEntriesManager = new LogEntriesManager();
-        killbillLogListener = new KillbillLogWriter(logEntriesManager);
+        killbillLogListener = new KillbillLogWriter(logEntriesManager, loggerFactory);
         context.addBundleListener(killbillLogListener);
         context.addFrameworkListener(killbillLogListener);
         context.addServiceListener(killbillLogListener);
+
+        context.registerService(LoggerFactory.class, loggerFactory, null);
         context.registerService(LogService.class.getName(), killbillLogListener, null);
 
         // Registrar for bundle

--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLogger.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLogger.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.logger;
+
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerConsumer;
+
+class KillbillLogger implements Logger {
+
+    private final org.slf4j.Logger slf4jLogger;
+
+    public KillbillLogger(final String name) {
+        slf4jLogger = org.slf4j.LoggerFactory.getLogger(name);
+    }
+
+    @Override
+    public String getName() {
+        return slf4jLogger.getName();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return slf4jLogger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(final String message) {
+        slf4jLogger.trace(message);
+    }
+
+    @Override
+    public void trace(final String format, final Object arg) {
+        slf4jLogger.trace(format, arg);
+    }
+
+    @Override
+    public void trace(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.trace(format, arg1, arg2);
+    }
+
+    @Override
+    public void trace(final String format, final Object... arguments) {
+        slf4jLogger.trace(format, arguments);
+    }
+
+    @Override
+    public <E extends Exception> void trace(final LoggerConsumer<E> consumer) throws E {
+        consumer.accept(this);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return slf4jLogger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(final String message) {
+        slf4jLogger.debug(message);
+    }
+
+    @Override
+    public void debug(final String format, final Object arg) {
+        slf4jLogger.debug(format, arg);
+    }
+
+    @Override
+    public void debug(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.debug(format, arg1, arg2);
+    }
+
+    @Override
+    public void debug(final String format, final Object... arguments) {
+        slf4jLogger.debug(format, arguments);
+    }
+
+    @Override
+    public <E extends Exception> void debug(final LoggerConsumer<E> consumer) throws E {
+        consumer.accept(this);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return slf4jLogger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(final String message) {
+        slf4jLogger.info(message);
+    }
+
+    @Override
+    public void info(final String format, final Object arg) {
+        slf4jLogger.info(format, arg);
+    }
+
+    @Override
+    public void info(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.info(format, arg1, arg2);
+    }
+
+    @Override
+    public void info(final String format, final Object... arguments) {
+        slf4jLogger.info(format, arguments);
+    }
+
+    @Override
+    public <E extends Exception> void info(final LoggerConsumer<E> consumer) throws E {
+        consumer.accept(this);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return slf4jLogger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(final String message) {
+        slf4jLogger.warn(message);
+    }
+
+    @Override
+    public void warn(final String format, final Object arg) {
+        slf4jLogger.warn(format, arg);
+    }
+
+    @Override
+    public void warn(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.warn(format, arg1, arg2);
+    }
+
+    @Override
+    public void warn(final String format, final Object... arguments) {
+        slf4jLogger.warn(format, arguments);
+    }
+
+    @Override
+    public <E extends Exception> void warn(final LoggerConsumer<E> consumer) throws E {
+        consumer.accept(this);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return slf4jLogger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(final String message) {
+        slf4jLogger.error(message);
+    }
+
+    @Override
+    public void error(final String format, final Object arg) {
+        slf4jLogger.error(format, arg);
+    }
+
+    @Override
+    public void error(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.error(format, arg1, arg2);
+    }
+
+    @Override
+    public void error(final String format, final Object... arguments) {
+        slf4jLogger.error(format, arguments);
+    }
+
+    @Override
+    public <E extends Exception> void error(final LoggerConsumer<E> consumer) throws E {
+        consumer.accept(this);
+    }
+
+    @Override
+    public void audit(final String message) {
+        slf4jLogger.info(message);
+    }
+
+    @Override
+    public void audit(final String format, final Object arg) {
+        slf4jLogger.info(format, arg);
+    }
+
+    @Override
+    public void audit(final String format, final Object arg1, final Object arg2) {
+        slf4jLogger.info(format, arg1, arg2);
+    }
+
+    @Override
+    public void audit(final String format, final Object... arguments) {
+        slf4jLogger.info(format, arguments);
+    }
+}

--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLoggerFactory.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLoggerFactory.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+public class KillbillLoggerFactory implements LoggerFactory {
+
+    private final Bundle bundle;
+    private final Map<LoggersKey, Logger> loggers;
+
+    public KillbillLoggerFactory(final Bundle bundle) {
+        this.bundle = bundle;
+        this.loggers = new HashMap<>();
+    }
+
+    @Override
+    public Logger getLogger(final String name) {
+        return getLogger(name, KillbillLogger.class);
+    }
+
+    @Override
+    public Logger getLogger(final Class<?> clazz) {
+        return getLogger(clazz, KillbillLogger.class);
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final String name, final Class<L> loggerType) {
+        return getLogger(bundle, name, loggerType);
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final Class<?> clazz, final Class<L> loggerType) {
+        return getLogger(bundle, clazz.getName(), loggerType);
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final Bundle bundle, final String name, final Class<L> loggerType) {
+        final LoggersKey key = new LoggersKey(bundle, name);
+        final Logger logger = loggers.get(key);
+        if (logger != null) {
+            return (L) logger;
+        }
+        synchronized (loggers) {
+            final Logger newLogger = new KillbillLogger(key.getLoggerName());
+            loggers.put(key, newLogger);
+            return (L) newLogger;
+        }
+    }
+
+    public Logger getLogger() {
+        return getLogger((String) null);
+    }
+
+    @VisibleForTesting
+    int getLoggersSize() {
+        return loggers.size();
+    }
+
+    static class LoggersKey {
+
+        private final String loggerName;
+
+        public LoggersKey(final Bundle bundle) {
+            this(bundle, null);
+        }
+
+        public LoggersKey(final Bundle bundle, final String className) {
+            this.loggerName = createLoggerName(bundle, className);
+        }
+
+        public String getLoggerName() {
+            return loggerName;
+        }
+
+        @VisibleForTesting
+        static String createLoggerName(final Bundle bundle, String className) {
+            className = Objects.requireNonNullElse(className, "");
+            if (!className.isEmpty() && !className.isBlank()) {
+                return className;
+            }
+
+            // As per specs: https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.log.html#d0e2377
+            // "Normally the name of the class which is doing the logging is used as the logger name"
+            // But KillbillLogWriter need to support (obsolete) LogService where there's no way to access logger's class
+            // client. So we need logger name alternative: bundle+version as its name, or if not possible,
+            // use KillbillLogWriter as logger name.
+            final String bundleName = createBundleName(bundle);
+            if (!bundleName.isEmpty() && !bundleName.isBlank()) {
+                return bundleName;
+            }
+
+            return KillbillLogWriter.class.getName();
+        }
+
+        @VisibleForTesting
+        static String createBundleName(final Bundle bundle) {
+            if (bundle == null || bundle.getSymbolicName() == null || bundle.getSymbolicName().isBlank()) {
+                return "";
+            }
+            final String version = bundle.getVersion() == null ||
+                                   bundle.getVersion().toString() == null ||
+                                   bundle.getVersion().toString().isBlank()
+                                   ? Version.emptyVersion.toString() : bundle.getVersion().toString();
+            return bundle.getSymbolicName() + ":" + version.replace(".", "_");
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final LoggersKey that = (LoggersKey) o;
+            return loggerName.equals(that.loggerName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(loggerName);
+        }
+
+        @Override
+        public String toString() {
+            return "LoggersKey{ loggerName='" + loggerName + "' }";
+        }
+    }
+}

--- a/osgi-bundles/bundles/logger/src/test/java/org/killbill/billing/osgi/bundles/logger/TestKillbillLoggerFactory.java
+++ b/osgi-bundles/bundles/logger/src/test/java/org/killbill/billing/osgi/bundles/logger/TestKillbillLoggerFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.logger;
+
+import org.killbill.billing.osgi.bundles.logger.KillbillLoggerFactory.LoggersKey;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestKillbillLoggerFactory {
+
+    Bundle mockBundle(final String bundleName, final String versionString) {
+        final Version version = Mockito.mock(Version.class);
+        Mockito.when(version.toString()).thenReturn(versionString);
+
+        final Bundle result = Mockito.mock(Bundle.class);
+        Mockito.when(result.getSymbolicName()).thenReturn(bundleName);
+        Mockito.when(result.getVersion()).thenReturn(version);
+
+        return result;
+    }
+
+    @DataProvider(name = "createBundleNameParams")
+    Object[][] createBundleNameParams() {
+        return new Object[][] {
+                { mockBundle("bundle-a", "1.2.3"), "bundle-a:1_2_3" },
+                { mockBundle("bundle-b", "1.2"), "bundle-b:1_2" },
+                { mockBundle("bundle-c", ""), "bundle-c:0_0_0" },
+                { mockBundle("bundle-d", null), "bundle-d:0_0_0" },
+                { mockBundle("bundle-d", null), "bundle-d:0_0_0" },
+                { mockBundle(null, "1.2.3"), "" },
+                { mockBundle("", "1.2.3"), "" },
+                { mockBundle("   ", "1.2.3"), "" },
+                { null, "" }
+
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createBundleNameParams")
+    public void testLoggerKeysCreateBundleName(final Bundle bundle, final String expectedResult) {
+        final String result = LoggersKey.createBundleName(bundle);
+        Assert.assertEquals(result, expectedResult);
+    }
+
+    @DataProvider(name = "createLoggerNameParams")
+    Object[][] createLoggerNameParams() {
+        return new Object[][] {
+                // Class name take precedence
+                { mockBundle("bundle-a", "1.2.3"), "com.foo.Hello", "com.foo.Hello" },
+                { null, "com.other.World", "com.other.World" },
+
+                // className null, empty, or blank.
+                { mockBundle("bundle-b", "1.2.3"), " ", "bundle-b:1_2_3" },
+                { mockBundle("bundle-c", "1.2.3"), "", "bundle-c:1_2_3" },
+                { mockBundle("bundle-d", "1.2"), null, "bundle-d:1_2" },
+                { mockBundle("bundle-e", null), null, "bundle-e:0_0_0" },
+
+                // bundleName and className not sufficient, fall back to KillbillLogWriter
+                { mockBundle(null, "1.2.3"), "", "org.killbill.billing.osgi.bundles.logger.KillbillLogWriter" },
+                { null, " ", "org.killbill.billing.osgi.bundles.logger.KillbillLogWriter" },
+                { null, null, "org.killbill.billing.osgi.bundles.logger.KillbillLogWriter" }
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createLoggerNameParams")
+    public void testLoggerKeysCreateLoggerName(final Bundle bundle, final String className, final String expectedResult) {
+        final String result = LoggersKey.createLoggerName(bundle, className);
+        Assert.assertEquals(result, expectedResult);
+    }
+
+    @Test(groups = "fast")
+    public void testGetLogger() {
+        final Bundle bundle = mockBundle("super-bundle", "1.0.0");
+        final KillbillLoggerFactory loggerFactory = new KillbillLoggerFactory(bundle);
+
+        loggerFactory.getLogger().info("anything..");
+        Assert.assertEquals(loggerFactory.getLoggersSize(), 1);
+
+        loggerFactory.getLogger(bundle, null, KillbillLogger.class).info("anything..");
+        Assert.assertEquals(loggerFactory.getLoggersSize(), 1);
+
+        loggerFactory.getLogger(String.class).info("anything..");
+        loggerFactory.getLogger(Character.class).info("anything..");
+        Assert.assertEquals(loggerFactory.getLoggersSize(), 3);
+
+        loggerFactory.getLogger(bundle, Integer.class.getName(), KillbillLogger.class).info("same bundle, different class.");
+        Assert.assertEquals(loggerFactory.getLoggersSize(), 4);
+    }
+}

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/OSGIKillbillLogService.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/OSGIKillbillLogService.java
@@ -22,9 +22,11 @@ package org.killbill.billing.osgi.libs.killbill;
 import javax.annotation.Nullable;
 
 import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillServiceReference;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.log.LogService;
+import org.osgi.service.log.Logger;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.MDC;
 
@@ -93,5 +95,30 @@ public class OSGIKillbillLogService extends OSGIKillbillLibraryBase implements L
                 return null;
             }
         });
+    }
+
+    @Override
+    public Logger getLogger(final String name) {
+        throw new java.lang.UnsupportedOperationException("Deprecated. Plugins should be using slf4j directly.");
+    }
+
+    @Override
+    public Logger getLogger(final Class<?> clazz) {
+        throw new java.lang.UnsupportedOperationException("Deprecated. Plugins should be using slf4j directly.");
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final String name, final Class<L> loggerType) {
+        throw new java.lang.UnsupportedOperationException("Deprecated. Plugins should be using slf4j directly.");
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final Class<?> clazz, final Class<L> loggerType) {
+        throw new java.lang.UnsupportedOperationException("Deprecated. Plugins should be using slf4j directly.");
+    }
+
+    @Override
+    public <L extends Logger> L getLogger(final Bundle bundle, final String name, final Class<L> loggerType) {
+        throw new java.lang.UnsupportedOperationException("Deprecated. Plugins should be using slf4j directly.");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,13 @@
                 <artifactId>killbill-platform-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <!-- FIXME-PLATFORM-120: Move to killbill-oss-parent later -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.log</artifactId>
+                <version>1.5.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,6 @@
                 <artifactId>killbill-platform-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
-            <!-- FIXME-PLATFORM-120: Move to killbill-oss-parent later -->
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.service.log</artifactId>
-                <version>1.5.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
Notes: This is WIP

Initial implementation for #120 : 

1. We have [KillbillLoggerFactory](https://github.com/xsalefter/killbill-platform/blob/45025b78baf68a107b7bad5e0a62c868bf73bb25/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLoggerFactory.java), [KillbillLogger](https://github.com/xsalefter/killbill-platform/blob/45025b78baf68a107b7bad5e0a62c868bf73bb25/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLogger.java), where `KillbillLogger` delegate every OSGI's `Logger` method to SLF4J. 

2. Changes in [KillbillLogWriter](https://github.com/killbill/killbill-platform/compare/work-for-release-0.23.x...xsalefter:platform-120-update_osgi_log_to_1.5.0?expand=1#diff-8959a38c2283aba9fb2f0342093f915bba88a03d7c849f3bcb33b306d8e96efe) and [Activator](https://github.com/killbill/killbill-platform/compare/work-for-release-0.23.x...xsalefter:platform-120-update_osgi_log_to_1.5.0?expand=1#diff-b8d7a28389c91df123d36448cad90fd38df4a313d41ebf5917a391d11a9b48a1) show that _"KillbillLogWriter should essentially internally only rely on KillbillLoggerFactory / KillbillLogger"_.

3. So far, only tested against modified [killbill-hello-world-plugin](https://github.com/killbill/killbill-hello-world-java-plugin/), that `KillbillLoggerFactory` and `KillbillLogWriter` [injection works](https://github.com/xsalefter/killbill-hello-world-java-plugin/blob/platform-120-demo/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldServlet.java#L47) after configured in [HelloWorldActivator](https://github.com/xsalefter/killbill-hello-world-java-plugin/blob/platform-120-demo/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldActivator.java#L79).

More tests and fixes will coming, but this is here to make sure that I'm not going to wrong direction. Any input are more than welcome.
