### PR TITLE
Ts 58 part 1 : remove kpm bundles path

### DIFF
--- a/osgi-bundles/bundles/kpm/README.md
+++ b/osgi-bundles/bundles/kpm/README.md
@@ -5,7 +5,7 @@ The KPM OSGI bundle enables:
 * the `INSTALL` and `UNINSTALL` commands of the [Kill Bill plugins management APIs](https://github.com/killbill/killbill-docs/blob/v3/userguide/tutorials/plugin_management.adoc)
 * endpoints specific to [KPM UI](https://github.com/killbill/killbill-kpm-ui)
 
-The osgi bundle installation location will follow killbill's `org.killbill.osgi.bundle.install.dir` configuration property, 
+The osgi bundle installation location will follow Kill Bill's `org.killbill.osgi.bundle.install.dir` configuration property, 
 and set to `/var/tmp/bundles` if property not set.
 
 ## Configuration

--- a/osgi-bundles/bundles/kpm/README.md
+++ b/osgi-bundles/bundles/kpm/README.md
@@ -5,12 +5,14 @@ The KPM OSGI bundle enables:
 * the `INSTALL` and `UNINSTALL` commands of the [Kill Bill plugins management APIs](https://github.com/killbill/killbill-docs/blob/v3/userguide/tutorials/plugin_management.adoc)
 * endpoints specific to [KPM UI](https://github.com/killbill/killbill-kpm-ui)
 
+The osgi bundle installation location will follow killbill's `org.killbill.osgi.bundle.install.dir` configuration property, 
+and set to `/var/tmp/bundles` if property not set.
+
 ## Configuration
 
 Available global configuration properties:
 
 * `org.killbill.billing.plugin.kpm.kpmPath` (default: `kpm`)
-* `org.killbill.billing.plugin.kpm.bundlesPath` (default: `/var/tmp/bundles`)
 * `org.killbill.billing.plugin.kpm.nexusUrl` (default: `https://oss.sonatype.org`)
 * `org.killbill.billing.plugin.kpm.nexusRepository` (default: `releases`)
 * `org.killbill.billing.plugin.kpm.strictSSL` (default: `true`)

--- a/osgi-bundles/bundles/kpm/README.md
+++ b/osgi-bundles/bundles/kpm/README.md
@@ -6,7 +6,7 @@ The KPM OSGI bundle enables:
 * endpoints specific to [KPM UI](https://github.com/killbill/killbill-kpm-ui)
 
 The osgi bundle installation location will follow Kill Bill's `org.killbill.osgi.bundle.install.dir` configuration property, 
-and set to `/var/tmp/bundles` if property not set.
+and use `/var/tmp/bundles` if this property is not set.
 
 ## Configuration
 

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMWrapper.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMWrapper.java
@@ -55,6 +55,8 @@ public class KPMWrapper {
 
     private static final Logger logger = LoggerFactory.getLogger(KPMWrapper.class);
 
+    private static final String BUNDLE_INSTALL_DIR = "org.killbill.osgi.bundle.install.dir";
+
     public static final String PROPERTY_PREFIX = "org.killbill.billing.plugin.kpm.";
 
     private static final ExecutorService executor = Executors.newCachedThreadPool(daemonThreadsNamed("kpm-%s"));
@@ -78,7 +80,7 @@ public class KPMWrapper {
         this.adminUsername = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "adminUsername"), "admin");
         this.adminPassword = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "adminPassword"), "password");
         this.kpmPath = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "kpmPath"), "kpm");
-        this.bundlesPath = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "bundlesPath"), Paths.get("/var", "tmp", "bundles").toString());
+        this.bundlesPath = Objects.requireNonNullElse(properties.getProperty(BUNDLE_INSTALL_DIR), Paths.get("/var", "tmp", "bundles").toString());
         this.nexusUrl = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusUrl"), "https://oss.sonatype.org");
         this.nexusRepository = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusRepository"), "releases");
         this.httpClient = new KPMClient(Boolean.parseBoolean(Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "strictSSL"), "true")),


### PR DESCRIPTION
As [discussed here](https://github.com/killbill/technical-support/issues/58#issuecomment-1399164711): 
- `bundlesPath` attribute in `KPMWrapper` will always get value from `org.killbill.osgi.bundle.install.dir`
- remove `.... .kpm.bundlesPath` configuration properties from docs.