### PR TITLE
ts-92 : install plugin via uri

### DIFF
--- a/osgi-bundles/bundles/kpm/pom.xml
+++ b/osgi-bundles/bundles/kpm/pom.xml
@@ -29,9 +29,14 @@
     <packaging>bundle</packaging>
     <name>killbill-platform-osgi-bundles-kpm</name>
     <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.osgi.bundles.kpm.*</osgi.private>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -40,9 +45,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- maven build keep failing and asking to add this, even though we're not use it here -->
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/osgi-bundles/bundles/kpm/spotbugs-exclude.xml
+++ b/osgi-bundles/bundles/kpm/spotbugs-exclude.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- Justification: Jackson need them -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.kpm.PluginIdentifier" />
+        <Or>
+            <Field name="language" type="java.lang.String" />
+            <Field name="packaging" type="java.lang.String" />
+        </Or>
+        <Bug pattern="SS_SHOULD_BE_STATIC" />
+    </Match>
+
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.kpm.impl.DefaultPluginManager" />
+        <Method name="&lt;init&gt;" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- FIXME-TS-58 : Remove this once technical-support-58 done -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.kpm.KPMWrapper" />
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.kpm.KPMWrapper" />
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+    </Match>
+</FindBugsFilter>

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/Activator.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/Activator.java
@@ -20,6 +20,7 @@
 package org.killbill.billing.osgi.bundles.kpm;
 
 import java.util.Hashtable;
+import java.util.Properties;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServlet;
@@ -27,6 +28,9 @@ import javax.servlet.http.HttpServlet;
 import org.jooby.json.Jackson;
 import org.killbill.billing.osgi.api.OSGIKillbillRegistrar;
 import org.killbill.billing.osgi.api.OSGIPluginProperties;
+import org.killbill.billing.osgi.bundles.kpm.impl.DefaultPluginFileService;
+import org.killbill.billing.osgi.bundles.kpm.impl.DefaultPluginIdentifierService;
+import org.killbill.billing.osgi.bundles.kpm.impl.DefaultPluginManager;
 import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
 import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
@@ -53,8 +57,14 @@ public class Activator extends KillbillActivatorBase {
         configProperties = new OSGIConfigPropertiesService(context);
         registrar = new OSGIKillbillRegistrar();
 
-        final KPMWrapper kpmWrapper = new KPMWrapper(killbillAPI, configProperties.getProperties());
-        eventsListener = new EventsListener(kpmWrapper);
+        final Properties properties = configProperties.getProperties();
+        final KPMWrapper kpmWrapper = new KPMWrapper(killbillAPI, properties);
+
+        final PluginFileService pluginFileService = new DefaultPluginFileService(properties);
+        final PluginIdentifierService pluginIdentifierService = new DefaultPluginIdentifierService(properties);
+
+        final PluginManager pluginManager = new DefaultPluginManager(killbillAPI, pluginFileService, pluginIdentifierService, properties);
+        eventsListener = new EventsListener(kpmWrapper, pluginManager);
 
         final Jackson jackson = new Jackson(PluginAppBuilder.DEFAULT_OBJECT_MAPPER);
         // JSON pass-through from KPM

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/EventsListener.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/EventsListener.java
@@ -42,10 +42,15 @@ public class EventsListener implements OSGIKillbillEventDispatcher.OSGIKillbillE
     private static final Logger logger = LoggerFactory.getLogger(EventsListener.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // FIXME-TS-58: Remove @Deprecated and delete KPMWrapper once technical-support-58 done
+    @Deprecated
     private final KPMWrapper kpmWrapper;
 
-    public EventsListener(final KPMWrapper kpmWrapper) {
+    private final PluginManager pluginManager;
+
+    public EventsListener(final KPMWrapper kpmWrapper, final PluginManager pluginManager) {
         this.kpmWrapper = kpmWrapper;
+        this.pluginManager = pluginManager;
     }
 
     @Override
@@ -94,10 +99,13 @@ public class EventsListener implements OSGIKillbillEventDispatcher.OSGIKillbillE
             final String pluginUri = props.get("pluginUri");
             if (pluginUri != null) {
                 try {
+                    // FIXME-TS-58: Remove this comments block once TS-58 done
+                    /*
                     kpmWrapper.install(nodeCommandMetadata.getPluginKey(),
                                        pluginUri,
                                        nodeCommandMetadata.getPluginVersion(),
-                                       pluginType);
+                                       pluginType);*/
+                    pluginManager.install(pluginUri, nodeCommandMetadata.getPluginKey(), nodeCommandMetadata.getPluginVersion());
                 } catch (final Exception e) {
                     logger.warn("Unable to install plugin {}", nodeCommandMetadata.getPluginKey(), e);
                 }

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMPluginException.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMPluginException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+public class KPMPluginException extends RuntimeException {
+
+    public KPMPluginException(final Throwable e) {
+        super(e);
+    }
+
+    public KPMPluginException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMPluginOperationException.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMPluginOperationException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+public class KPMPluginOperationException extends KPMPluginException {
+
+    private enum Operation {
+        INSTALL, UNINSTALL;
+    }
+
+    private final Operation operation;
+
+    public KPMPluginOperationException(final Throwable e, final Operation operation) {
+        super(e);
+        this.operation = operation;
+    }
+
+    public static KPMPluginOperationException newInstallException(final Throwable e) {
+        return new KPMPluginOperationException(e, Operation.INSTALL);
+    }
+
+    public static KPMPluginOperationException newUninstallException(final Throwable e) {
+        return new KPMPluginOperationException(e, Operation.UNINSTALL);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " when doing " + operation;
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMWrapper.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KPMWrapper.java
@@ -45,12 +45,10 @@ import org.killbill.commons.utils.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.airlift.command.Command;
 import io.airlift.command.CommandFailedException;
 import io.airlift.units.Duration;
 
-@SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
 public class KPMWrapper {
 
     private static final Logger logger = LoggerFactory.getLogger(KPMWrapper.class);
@@ -111,7 +109,6 @@ public class KPMWrapper {
         return system(commands);
     }
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public void install(final String pluginKey, final String uri, final String pluginVersion, final String pluginType) throws IOException, InvalidRequest, URISyntaxException, InterruptedException {
         logger.info("Installing pluginKey='{}', uri='{}', pluginVersion='{}', pluginType='{}'",
                     pluginKey,

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginFileService.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginFileService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+
+import org.killbill.commons.utils.Strings;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+
+public interface PluginFileService {
+
+    @VisibleForTesting
+    String BUNDLE_INSTALL_DIR = "org.killbill.osgi.bundle.install.dir";
+
+    /**
+     * Get killbill bundles path. It will find property named {@code org.killbill.osgi.bundle.install.dir}, or
+     * {@code /var/tmp/bundles} if property not exist.
+     */
+    static Path getBundlesPath(final Properties properties) {
+        final String bundleInstallDir = properties.getProperty(BUNDLE_INSTALL_DIR);
+        return Strings.isNullOrEmpty(bundleInstallDir) ? Path.of("/var", "tmp", "bundles") : Path.of(bundleInstallDir);
+    }
+
+    /**
+     * Get download path. This is usually temporary path where plugin file should be downloaded before processed further.
+     * This is satisfies "Current Implementation" point 5 section in
+     * <a href="https://github.com/killbill/technical-support/issues/92">this issue</a>.
+     */
+    static Path createTmpDownloadPath() throws IOException {
+        return Files.createTempDirectory("kpm-" + System.currentTimeMillis()).toAbsolutePath();
+    }
+
+    /**
+     * Create directory for actual plugin location. {@link Path} object returned by this method:
+     * <ol>
+     *     <li>Will actually exist in file system</li>
+     *     <li>One of hierarchical sequence should contains correct <strong>plugin name</strong>.</li>
+     *     <li>One of hierarchical sequence should contains version with public <strong>semantic versioning</strong> format.</li>
+     *     <li>
+     *         plugin name and version will always be in {@code <plugin-name><fs-separator><version>} format.
+     *         For example {@code helloworld-plugin/3.0.0}, {@code super-plugin/4.3.1}, etc.
+     *     </li>
+     * </ol>
+     */
+    Path createPluginDirectory(String pluginKey, String pluginVersion) throws IOException;
+
+    /**
+     * Create symlink for directory. Port
+     * <a href="https://github.com/killbill/killbill-cloud/blob/master/kpm/lib/kpm/plugins_manager.rb#L22">setActive</a>
+     * operation.
+     *
+     * @return symlink {@link Path}.
+     */
+    void createSymlink(@Nonnull final Path pluginDirectory) throws IOException;
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginIdentifier.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginIdentifier.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+import java.util.Objects;
+
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class PluginIdentifier {
+
+    private final String pluginName;
+    private final String groupId;
+    private final String artifactId;
+    private final String packaging = "jar";
+    private final String classifier;
+    private final String version;
+    private final String language = "java";
+
+    private PluginIdentifier(final String pluginName,
+                             final String groupId,
+                             final String artifactId,
+                             final String classifier,
+                             final String version) {
+        this.pluginName = pluginName;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.classifier = classifier;
+        this.version = version;
+    }
+
+    public PluginIdentifier(final String pluginName, final String version) {
+        this(pluginName, null, null, null, version);
+    }
+
+    // Required by jackson.
+    @VisibleForTesting
+    PluginIdentifier() {
+        this(null, null, null, null, null);
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getPackaging() {
+        return packaging;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PluginIdentifier that = (PluginIdentifier) o;
+        return pluginName.equals(that.pluginName) &&
+               Objects.equals(groupId, that.groupId) &&
+               Objects.equals(artifactId, that.artifactId) &&
+               Objects.equals(classifier, that.classifier) &&
+               version.equals(that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginName, groupId, artifactId, packaging, classifier, version, language);
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginIdentifierService.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginIdentifierService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+public interface PluginIdentifierService {
+
+    void add(final String pluginKey, final String version);
+
+    void remove(final String pluginKey);
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginInstaller.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginInstaller.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+public interface PluginInstaller {
+
+    void install() throws KPMPluginOperationException;
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginManager.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/PluginManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+import java.util.SortedSet;
+
+public interface PluginManager {
+
+    String PROPERTY_PREFIX = "org.killbill.billing.plugin.kpm.";
+
+    SortedSet<PluginIdentifier> getAvailablePlugins(final String kbVersion, final boolean forceDownload) throws KPMPluginException;
+
+    void install(final String uri, final String pluginKey, final String pluginVersion) throws KPMPluginException;
+
+    // KPMWrapper have parameter named 'pluginPackaging'. Get removed since its value will always 'JAR'
+    // KPMWrapper have parameter named 'pluginType', because back then, we have 'install_java_plugins' vs
+    //   'install_ruby_plugins'. Now we have just 'install_java_plugins'
+    void install(final String pluginKey,
+                 final String killbillVersion,
+                 final String pluginGroupId,
+                 final String pluginArtifactId,
+                 final String pluginVersion,
+                 final String pluginClassifier,
+                 final boolean forceDownload) throws KPMPluginException;
+
+    void uninstall(final String pluginKey, final String version) throws KPMPluginException;
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginFileService.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginFileService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import javax.annotation.Nonnull;
+
+import org.killbill.billing.osgi.bundles.kpm.PluginFileService;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+
+public class DefaultPluginFileService implements PluginFileService {
+
+    @VisibleForTesting
+    static final String DEFAULT_SYMLINK_NAME = "SET_DEFAULT";
+
+    private final Path bundlesPath;
+
+    public DefaultPluginFileService(final Properties properties) {
+        this.bundlesPath = PluginFileService.getBundlesPath(properties);
+    }
+
+    @Override
+    public Path createPluginDirectory(final String pluginKey, final String pluginVersion) throws IOException {
+        final PluginNamingResolver pluginNamingResolver = PluginNamingResolver.of(pluginKey, pluginVersion);
+        final String pluginName = pluginNamingResolver.getPluginName();
+        final String fixedVersion = pluginNamingResolver.getPluginVersion();
+        final Path pluginDirectory = Path.of(bundlesPath.toString(), "plugins", "java", pluginName, fixedVersion);
+        return Files.createDirectories(pluginDirectory);
+    }
+
+    @Override
+    public void createSymlink(@Nonnull final Path pluginDirectory) throws IOException {
+        final Path symlink = pluginDirectory.resolveSibling(DEFAULT_SYMLINK_NAME);
+        final Path parentDir = symlink.getParent();
+        // (null check required by spotbugs) Files.createSymbolicLink(path) mandates that parent directory should exist ....
+        if (parentDir != null) {
+            Files.createDirectories(parentDir);
+        }
+        // .... BUT symbolic link directory should not.
+        Files.deleteIfExists(symlink);
+        Files.createSymbolicLink(symlink, pluginDirectory);
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginIdentifierService.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginIdentifierService.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.killbill.billing.osgi.bundles.kpm.KPMPluginException;
+import org.killbill.billing.osgi.bundles.kpm.PluginFileService;
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifier;
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifierService;
+import org.killbill.commons.utils.Preconditions;
+import org.killbill.commons.utils.Strings;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+public class DefaultPluginIdentifierService implements PluginIdentifierService {
+
+    private static final String FILE_NAME = "plugin_identifiers.json";
+
+    private final ObjectMapper objectMapper;
+
+    @VisibleForTesting
+    final File file;
+
+    public DefaultPluginIdentifierService(final Properties properties) {
+        objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(Include.NON_NULL);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+        final Path bundlesPath = PluginFileService.getBundlesPath(properties);
+        final Path directory = Path.of(bundlesPath.toString(), "plugins");
+
+        try {
+            Files.createDirectories(directory);
+            file = Path.of(directory.toString(), FILE_NAME).toFile();
+            if (file.createNewFile()) {
+                objectMapper.writeValue(file, Collections.emptyMap());
+            }
+        } catch (final IOException e) {
+            throw new KPMPluginException(e);
+        }
+    }
+
+    @VisibleForTesting
+    Map<String, PluginIdentifier> loadFileContent() {
+        try {
+            return objectMapper.readValue(file, new TypeReference<>() {});
+        } catch (final IOException e) {
+            throw new KPMPluginException(String.format("Cannot load %s content", file), e);
+        }
+    }
+
+    @VisibleForTesting
+    void writeContentToFile(final Map<String, PluginIdentifier> contents) {
+        try {
+            objectMapper.writeValue(file, contents);
+        } catch (final IOException e) {
+            throw new KPMPluginException(String.format("Cannot write to %s. Content value: %s", file, contents.toString()), e);
+        }
+    }
+
+    @Override
+    public void add(final String pluginKey, final String version) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pluginKey), "'pluginKey' cannot be null or empty");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(version), "'version' cannot be null or empty");
+
+        final PluginNamingResolver namingResolver = PluginNamingResolver.of(pluginKey, version);
+
+        final Map<String, PluginIdentifier> content = loadFileContent();
+        content.put(pluginKey, new PluginIdentifier(namingResolver.getPluginName(), namingResolver.getPluginVersion()));
+
+        writeContentToFile(content);
+    }
+
+    @Override
+    public void remove(final String pluginKey) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pluginKey), "'pluginKey' cannot be null or empty");
+
+        final Map<String, PluginIdentifier> content = loadFileContent();
+        content.remove(pluginKey);
+
+        writeContentToFile(content);
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginManager.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginManager.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.SortedSet;
+
+import org.killbill.billing.osgi.api.PluginStateChange;
+import org.killbill.billing.osgi.bundles.kpm.KPMClient;
+import org.killbill.billing.osgi.bundles.kpm.KPMPluginOperationException;
+import org.killbill.billing.osgi.bundles.kpm.PluginFileService;
+import org.killbill.billing.osgi.bundles.kpm.KPMPluginException;
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifierService;
+import org.killbill.billing.osgi.bundles.kpm.PluginInstaller;
+import org.killbill.billing.osgi.bundles.kpm.PluginManager;
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifier;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultPluginManager implements PluginManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultPluginManager.class);
+
+    private final OSGIKillbillAPI killbillApi;
+    private final KPMClient httpClient;
+    private final PluginFileService pluginFileService;
+    private final PluginIdentifierService pluginIdentifierService;
+    private final String adminUsername;
+    private final String adminPassword;
+
+    public DefaultPluginManager(final OSGIKillbillAPI killbillApi,
+                                final PluginFileService pluginFileService,
+                                final PluginIdentifierService pluginIdentifierService,
+                                final Properties properties) {
+        this.killbillApi = killbillApi;
+        this.pluginFileService = pluginFileService;
+        this.pluginIdentifierService = pluginIdentifierService;
+        this.httpClient = createHttpClient(properties);
+
+        this.adminUsername = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "adminUsername"), "admin");
+        this.adminPassword = Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "adminPassword"), "password");
+    }
+
+    private KPMClient createHttpClient(final Properties properties) {
+        final boolean strictSSL = Boolean.parseBoolean(Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "strictSSL"), "true"));
+        final int connectTimeOutMs = Integer.parseInt(Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "connectTimeoutSec"), "60")) * 1000;
+        final int readTimeOutMs = Integer.parseInt(Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "readTimeoutSec"), "60")) * 1000;
+
+        try {
+            // If exceptions are thrown here, the plugin cannot work properly in the first place
+            return new KPMClient(strictSSL, connectTimeOutMs, readTimeOutMs);
+        } catch (final GeneralSecurityException e) {
+            throw new KPMPluginException("Cannot create KpmHttpClient, there's problem with SSL context creation.", e);
+        }
+    }
+
+    private void notifyFileSystemChange(final PluginStateChange newState,
+                                        final String pluginKey,
+                                        final String pluginVersion) {
+        try {
+            logger.info("Notifying Kill Bill: state='{}', pluginKey='{}', pluginVersion={}", newState, pluginKey, pluginVersion);
+            killbillApi.getSecurityApi().login(adminUsername, adminPassword);
+            killbillApi.getPluginsInfoApi().notifyOfStateChanged(newState,
+                                                                 pluginKey,
+                                                                 null, // Not needed
+                                                                 pluginVersion,
+                                                                 null /* Unused */);
+        } finally {
+            killbillApi.getSecurityApi().logout();
+        }
+    }
+
+    @Override
+    public SortedSet<PluginIdentifier> getAvailablePlugins(final String kbVersion, final boolean forceDownload) throws KPMPluginException {
+        return null;
+    }
+
+    @Override
+    public void install(final String uri, final String pluginKey, final String pluginVersion) throws KPMPluginException {
+        final PluginNamingResolver namingResolver = PluginNamingResolver.of(pluginKey, pluginVersion, uri);
+        try {
+            // Prepare temp file as download location
+            final Path downloadDirectory = PluginFileService.createTmpDownloadPath();
+            final String pluginFileName = namingResolver.getPluginJarFileName();
+            final String fixedVersion = namingResolver.getPluginVersion();
+            final Path downloadedFile = downloadDirectory.resolve(pluginFileName);
+            // Download
+            httpClient.downloadPlugin(uri, downloadedFile);
+
+            // install
+            final PluginInstaller pluginInstaller = new URIBasedPluginInstaller(pluginFileService, downloadedFile, pluginKey, fixedVersion);
+            pluginInstaller.install();
+
+            notifyFileSystemChange(PluginStateChange.NEW_VERSION, pluginKey, fixedVersion);
+
+            // Add/update plugin identifier
+            pluginIdentifierService.add(pluginKey, fixedVersion);
+
+        } catch (final Exception e) {
+            throw KPMPluginOperationException.newInstallException(e);
+        }
+    }
+
+    @Override
+    public void install(final String pluginKey,
+                        final String killbillVersion,
+                        final String pluginGroupId,
+                        final String pluginArtifactId,
+                        final String pluginVersion,
+                        final String pluginClassifier,
+                        final boolean forceDownload) throws KPMPluginException {
+
+    }
+
+    @Override
+    public void uninstall(final String pluginKey, final String version) throws KPMPluginException {
+
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/PluginNamingResolver.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/PluginNamingResolver.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.killbill.commons.utils.Preconditions;
+import org.killbill.commons.utils.Strings;
+
+class PluginNamingResolver {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("([1-9]\\d*)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9]+))?");
+
+    private final String pluginKey;
+    private final String pluginVersion;
+
+    private String stringContainsVersion;
+
+    PluginNamingResolver(final String pluginKey, final String pluginVersion) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pluginKey), "pluginKey is null or empty");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pluginVersion), "pluginVersion is null or empty");
+        this.pluginKey = pluginKey;
+        this.pluginVersion = pluginVersion;
+    }
+
+    static PluginNamingResolver of(final String pluginKey, final String pluginVersion) {
+        return new PluginNamingResolver(pluginKey, pluginVersion);
+    }
+
+    /**
+     * Create instance of {@code PluginNamingResolver}, guess version value from {@code stringContainsVersion} if
+     * {@code pluginVersion} not match any version format.
+     */
+    static PluginNamingResolver of(final String pluginKey, final String pluginVersion, final String stringContainsVersion) {
+        final PluginNamingResolver result = of(pluginKey, pluginVersion);
+        result.stringContainsVersion = stringContainsVersion;
+        return result;
+    }
+
+    String getPluginName() {
+        return pluginKey + "-plugin";
+    }
+
+    String getPluginVersion() {
+        String result = getVersionFromString(pluginVersion);
+        if (Strings.isNullOrEmpty(result) && !Strings.isNullOrEmpty(stringContainsVersion)) {
+            result = getVersionFromString(stringContainsVersion);
+        }
+
+        return Strings.isNullOrEmpty(result) ? "0.0.0" : result;
+    }
+
+    String getPluginJarFileName() {
+        return getPluginName().concat("-").concat(getPluginVersion()).concat(".jar");
+    }
+
+    /**
+     * <a href="https://github.com/killbill/killbill-cloud/blob/master/kpm/lib/kpm/base_installer.rb#L166">See here</a>.
+     */
+    static String getVersionFromString(final String string) {
+        final Matcher matcher = VERSION_PATTERN.matcher(string);
+        if (!matcher.find()) {
+            return null;
+        }
+        return matcher.group(0).replaceAll("(?i)-{1,2}SNAPSHOT", "");
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/URIBasedPluginInstaller.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/URIBasedPluginInstaller.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+import org.killbill.billing.osgi.bundles.kpm.PluginFileService;
+import org.killbill.billing.osgi.bundles.kpm.KPMPluginOperationException;
+import org.killbill.billing.osgi.bundles.kpm.PluginInstaller;
+
+public class URIBasedPluginInstaller implements PluginInstaller {
+
+    private final PluginFileService pluginFileService;
+    private final Path downloadedFile;
+    private final String pluginKey;
+    private final String pluginVersion;
+
+    public URIBasedPluginInstaller(final PluginFileService pluginFileService,
+                                   final Path downloadedFile,
+                                   final String pluginKey,
+                                   final String pluginVersion) {
+        this.pluginFileService = Objects.requireNonNull(pluginFileService);
+        this.downloadedFile = Objects.requireNonNull(downloadedFile);
+        this.pluginKey = Objects.requireNonNull(pluginKey);
+        this.pluginVersion = pluginVersion;
+    }
+
+    /**
+     * See point 6 of "Current Implementation" in <a href="https://github.com/killbill/technical-support/issues/92">this issue</a>.
+     */
+    @Override
+    public void install() throws KPMPluginOperationException {
+        try {
+            // Make directory
+            final Path pluginDirectory = pluginFileService.createPluginDirectory(pluginKey, pluginVersion);
+
+            // Copy downloadedFile to directory
+            Files.copy(downloadedFile,
+                       pluginDirectory.resolve(PluginNamingResolver.of(pluginKey, pluginVersion).getPluginJarFileName()),
+                       StandardCopyOption.REPLACE_EXISTING);
+
+            // Make symlink
+            pluginFileService.createSymlink(pluginDirectory);
+        } catch (final IOException e) {
+            throw KPMPluginOperationException.newInstallException(e);
+        }
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/TestUtils.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/TestUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.killbill.billing.osgi.bundles.kpm.impl.DefaultPluginFileService;
+import org.killbill.commons.utils.io.Resources;
+
+public class TestUtils {
+
+    /**
+     * Get maven's "src/test/resources" directory path of this maven module.
+     */
+    public static Path getTestPath(final String... path) {
+        return Path.of(Resources.getResource(".").getPath(), path);
+    }
+
+    public static Properties getTestProperties() {
+        final Properties properties = new Properties();
+        properties.setProperty(DefaultPluginFileService.BUNDLE_INSTALL_DIR, TestUtils.getTestPath().toString());
+        return properties;
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginFileService.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginFileService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import org.killbill.billing.osgi.bundles.kpm.TestUtils;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.testng.Assert;
+
+public class TestDefaultPluginFileService {
+    private DefaultPluginFileService pluginFileService;
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() {
+        pluginFileService = new DefaultPluginFileService(TestUtils.getTestProperties());
+    }
+
+    @DataProvider(name = "createPluginDirectoryParams")
+    Object[][] createPluginDirectoryParams() {
+        return new Object[][] {
+                { "helloworld", "1.2.1" },
+                { "super-code", "1.2.3-SNAPSHOT" },
+                { "CONTAINS_UPPER_CASE", "1.2.3-RC2" },
+                { "helloworld", "1.2.1" } // Make sure that rewrite directory is Ok
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createPluginDirectoryParams")
+    public void testCreatePluginDirectory(final String pluginKey, final String pluginVersion) throws IOException {
+        final Path pluginDirectory = pluginFileService.createPluginDirectory(pluginKey, pluginVersion);
+        final String actualVersion = PluginNamingResolver.getVersionFromString(pluginVersion);
+
+        Assert.assertEquals(pluginDirectory, TestUtils.getTestPath("plugins", "java", pluginKey + "-plugin", actualVersion));
+        Assert.assertTrue(Files.isDirectory(pluginDirectory));
+    }
+
+    @Test(groups = "fast")
+    public void testCreateSymlink() throws IOException {
+        final Path pluginDirectory = TestUtils.getTestPath("plugins", "symlink-test");
+
+        final Path symlink = pluginDirectory.resolveSibling(DefaultPluginFileService.DEFAULT_SYMLINK_NAME);
+
+
+        pluginFileService.createSymlink(pluginDirectory);
+
+        Assert.assertTrue(Files.isSymbolicLink(symlink));
+        Assert.assertEquals(Files.readSymbolicLink(symlink), pluginDirectory);
+    }
+}
+

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginIdentifierService.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginIdentifierService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifier;
+import org.killbill.billing.osgi.bundles.kpm.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestDefaultPluginIdentifierService {
+
+    private DefaultPluginIdentifierService pluginIdentifierService;
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() {
+        pluginIdentifierService = new DefaultPluginIdentifierService(TestUtils.getTestProperties());
+    }
+
+    @AfterMethod(groups = "fast")
+    public void afterMethod() {
+        pluginIdentifierService.file.delete();
+    }
+
+    @Test(groups = "fast")
+    public void testAdd() {
+        Map<String, PluginIdentifier> content = pluginIdentifierService.loadFileContent();
+        Assert.assertEquals(content.size(), 0);
+
+        final String pluginKey = "testPlugin";
+        final String version = "1.0";
+        final PluginNamingResolver pluginNamingResolver = PluginNamingResolver.of(pluginKey, version);
+
+        pluginIdentifierService.add(pluginKey, version);
+
+        content = pluginIdentifierService.loadFileContent();
+        final PluginIdentifier pluginIdentifier = content.get(pluginKey);
+        Assert.assertEquals(content.size(), 1);
+        Assert.assertNotNull(pluginIdentifier);
+        Assert.assertEquals(pluginIdentifier.getPluginName(), pluginNamingResolver.getPluginName());
+        Assert.assertEquals(pluginIdentifier.getVersion(), pluginNamingResolver.getPluginVersion());
+    }
+
+    @Test(groups = "fast")
+    public void testRemove() {
+        final String pluginKey = "testPlugin";
+        final String version = "1.0";
+        pluginIdentifierService.add(pluginKey, version);
+
+        pluginIdentifierService.remove(pluginKey);
+
+        final Map<String, PluginIdentifier> content = pluginIdentifierService.loadFileContent();
+        Assert.assertEquals(content.size(), 0);
+    }
+}
+

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestPluginNamingResolver.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestPluginNamingResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestPluginNamingResolver {
+
+    @DataProvider(name = "createGetVersionFromStringParams")
+    Object[][] createGetVersionFromStringParams() {
+        return new Object[][] {
+                { "plugin-a-1.2.1.jar", "1.2.1" },
+                { "plugin-b-1.2.3-SNAPSHOT.jar", "1.2.3" },
+                { "my.super.plugin.1.2.3-snapshot.jar", "1.2.3" }
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createGetVersionFromStringParams")
+    public void testGetVersionFromString(final String version, final String expectedVersion) {
+        final String result = PluginNamingResolver.getVersionFromString(version);
+        Assert.assertEquals(result, expectedVersion);
+    }
+
+    @DataProvider(name = "createGetPluginNameParams")
+    Object[][] createGetPluginNameParams() {
+        return new Object[][] {
+                { "helloworld", "helloworld-plugin" },
+                { "super-plugin", "super-plugin-plugin" }, // this is what we have in KPM
+                { "this-is-plugin-that-actually-not-plugin", "this-is-plugin-that-actually-not-plugin-plugin" } // see above
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createGetPluginNameParams")
+    public void testGetPluginName(final String pluginKey, final String expectedPluginName) {
+        final PluginNamingResolver pluginNamingResolver = PluginNamingResolver.of(pluginKey, "0.0.0"); // version not actually needed
+        Assert.assertEquals(pluginNamingResolver.getPluginName(), expectedPluginName);
+    }
+
+    @DataProvider(name = "createGetPluginVersionParams")
+    Object[][] createGetPluginVersionParams() {
+        return new Object[][] {
+                { "1.0.0-SNAPSHOT", "not-needed", "1.0.0" },
+                { "not-a-version", "https://maven.company.com/releases/com/company/killbill/plugins/superplugin/superplugin-1.2.3.jar", "1.2.3" },
+                { "not-a-version", "https://myapp.com/no-version-involved", "0.0.0" }
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createGetPluginVersionParams")
+    public void testGetPluginVersion(final String pluginVersion, final String strContainsVersion, final String expectedVersion) {
+        // pluginKey not needed here.
+        final PluginNamingResolver namingResolver = PluginNamingResolver.of("helloworld", pluginVersion, strContainsVersion);
+        Assert.assertEquals(namingResolver.getPluginVersion(), expectedVersion);
+    }
+
+    @DataProvider(name = "createGetPluginJarFileNameParams")
+    Object[][] createGetPluginJarFileNameParams() {
+        return new Object[][] {
+                { "helloworld", "1.2.3", "helloworld-plugin-1.2.3.jar" },
+                { "super-plugin", "1.1.2", "super-plugin-plugin-1.1.2.jar" }, // this is what we have in KPM
+                { "snapshot-test", "9.0.1-SNAPSHOT", "snapshot-test-plugin-9.0.1.jar" }
+        };
+    }
+
+    @Test(groups = "fast", dataProvider = "createGetPluginJarFileNameParams")
+    public void testGetPluginJarFileName(final String pluginKey, final String version, final String expectedJarFileName) {
+        final PluginNamingResolver pluginNamingResolver = PluginNamingResolver.of(pluginKey, version);
+        Assert.assertEquals(pluginNamingResolver.getPluginJarFileName(), expectedJarFileName);
+    }
+}

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestURIBasedPluginInstaller.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestURIBasedPluginInstaller.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.bundles.kpm.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.killbill.billing.osgi.bundles.kpm.PluginFileService;
+import org.killbill.billing.osgi.bundles.kpm.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestURIBasedPluginInstaller {
+
+    private final Path testPath = TestUtils.getTestPath("plugins", "uri-installer-test", "temp");
+
+    private URIBasedPluginInstaller pluginInstaller;
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() throws IOException {
+        final PluginFileService pluginFileService = new DefaultPluginFileService(TestUtils.getTestProperties());
+        final Path downloadedDir = Files.createDirectories(testPath);
+        final Path downloadedFile = downloadedDir.resolve("downloaded-file-jar.txt");
+        if (!Files.exists(downloadedFile)) {
+            Files.createFile(downloadedFile);
+        }
+        pluginInstaller = new URIBasedPluginInstaller(pluginFileService, downloadedFile, "superjar", "1.0.0-SNAPSHOT");
+    }
+
+    @Test(groups = "fast")
+    public void testInstall() {
+        // Make sure all test files available
+        Assert.assertTrue(Files.exists(testPath));
+        Assert.assertTrue(Files.exists(testPath.resolve("downloaded-file-jar.txt")));
+
+        pluginInstaller.install();
+
+        final Path pluginDirectory = TestUtils.getTestPath("plugins", "java", // "plugin/java" created by pluginFileService.createPluginDirectory()
+                                                           "superjar-plugin", // "superjar" is pluginKey (see above). We always add "-plugin"
+                                                           "1.0.0"); // "snapshot should get removed
+        final Path pluginFile = pluginDirectory.resolve("superjar-plugin-1.0.0.jar");
+        final Path symlink = TestUtils.getTestPath("plugins", "java", "superjar-plugin", DefaultPluginFileService.DEFAULT_SYMLINK_NAME);
+
+        Assert.assertTrue(Files.exists(pluginDirectory));
+        Assert.assertTrue(Files.exists(pluginFile));
+        Assert.assertTrue(Files.isRegularFile(pluginFile));
+        Assert.assertTrue(Files.exists(symlink));
+    }
+}
+

--- a/osgi-bundles/bundles/kpm/src/test/resources/plugins/symlink-test/plugin-jar.txt
+++ b/osgi-bundles/bundles/kpm/src/test/resources/plugins/symlink-test/plugin-jar.txt
@@ -1,0 +1,1 @@
+used by TestDefaultPluginFileService to create symlink.

--- a/osgi-bundles/bundles/kpm/src/test/resources/plugins/uri-installer-test/temp/downloaded-file-jar.txt
+++ b/osgi-bundles/bundles/kpm/src/test/resources/plugins/uri-installer-test/temp/downloaded-file-jar.txt
@@ -1,0 +1,1 @@
+used by TestURIBasedPluginInstaller


### PR DESCRIPTION
See this issue: https://github.com/killbill/technical-support/issues/92 . Part of https://github.com/killbill/technical-support/issues/58

- There are some unnecessary interfaces, like [`PluginIdentifierService`](https://github.com/killbill/killbill-platform/pull/132/files#diff-7a125a952a3c1433fb73c591722367a6d0f689058d1bbef1c7ab1d1340083b50) and [`PluginFileService`](https://github.com/killbill/killbill-platform/pull/132/files#diff-72aec8b2d13690284aeb10f83dfeabbe6a0246f164c8fcdaa986df3a65d413a1). But those interfaces help separating functionality better (well, at least for me).

- Originally, KPM write these JSON to `plugin_identifiers.json` when installing via KAUI with URI:
  ```json
  {
    "stripe": {
      "plugin_name": "stripe-plugin",
      "language": "java"
    }
  }
  ```
  but now it writes:
  ```javascript
  {
    "stripe": {
      "plugin_name": "stripe-plugin",
      "packaging": "jar", // always JAR, since ruby support now removed.
      "version": "8.0.0", // because defined in UI. If version is not valid, this will set to "0.0.0"
      "language": "java"
    }
  }
  ```