### PR TITLE
address spotbugs for killbill-platform-osgi module

### DIFF
--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -28,6 +28,9 @@
     <artifactId>killbill-platform-osgi</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-osgi</name>
+    <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -56,10 +59,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/osgi/spotbugs-exclude.xml
+++ b/osgi/spotbugs-exclude.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.glue.DefaultOSGIModule" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.KillbillEventRetriableBusHandler" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.OSGIAppender" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.OSGIListener" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.KillbillActivator" />
+        <Or>
+            <Method name="&lt;init&gt;"/>
+            <Method name="start"/>
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.api.DefaultPluginsInfoApi" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.DefaultOSGIService" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <!-- This class is just getter-setter. Listing all methods here is kinda pointless -->
+        <Class name="org.killbill.billing.osgi.DefaultOSGIKillbill" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.http.DefaultHttpService" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
@@ -38,8 +38,6 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class BundleRegistry {
 
     private static final Logger log = LoggerFactory.getLogger(BundleRegistry.class);
@@ -168,7 +166,7 @@ public class BundleRegistry {
 
         public BundleWithMetadata(final BundleWithConfig bundleWithConfig) {
             super(bundleWithConfig.getBundle(), bundleWithConfig.getConfig());
-            serviceNames = new HashSet<PluginServiceInfo>();
+            serviceNames = new HashSet<>();
         }
 
         public String getPluginName() {
@@ -187,9 +185,8 @@ public class BundleRegistry {
             serviceNames.remove(new DefaultPluginServiceInfo(serviceTypeName, registrationName));
         }
 
-        @SuppressFBWarnings("EI_EXPOSE_REP")
         public Set<PluginServiceInfo> getServiceNames() {
-            return serviceNames;
+            return new HashSet<>(serviceNames);
         }
     }
 

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIKillbill.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIKillbill.java
@@ -45,9 +45,6 @@ import org.killbill.billing.util.api.RecordIdApi;
 import org.killbill.billing.util.api.TagUserApi;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class DefaultOSGIKillbill implements OSGIKillbill {
 
     private AccountUserApi accountUserApi;

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -41,11 +41,7 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class DefaultOSGIService implements OSGIService {
-
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultOSGIService.class);
 
@@ -131,9 +127,8 @@ public class DefaultOSGIService implements OSGIService {
         }
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP")
     public List<BundleWithConfig> getInstalledBundles() {
-        return installedBundles;
+        return List.copyOf(installedBundles);
     }
 
     private Framework createAndInitFramework() throws BundleException {

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
@@ -67,9 +67,6 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class KillbillActivator implements BundleActivator, AllServiceListener {
 
     static final int PLUGIN_NAME_MAX_LENGTH = 40;
@@ -180,7 +177,7 @@ public class KillbillActivator implements BundleActivator, AllServiceListener {
     @Override
     public void start(final BundleContext context) throws Exception {
         this.context = context;
-        final Dictionary<String, String> props = new Hashtable<String, String>();
+        final Dictionary<String, String> props = new Hashtable<>();
         props.put(OSGIPluginProperties.PLUGIN_NAME_PROP, "killbill");
 
         // Forward all core log entries to the OSGI LogService, so that plugins have access to them

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
@@ -55,10 +55,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 // Needs to be injected for the lifecycle logic
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class KillbillEventRetriableBusHandler extends RetryableService implements KillbillEventRetriableBusHandlerService {
 
     private final Logger logger = LoggerFactory.getLogger(KillbillEventRetriableBusHandler.class);

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
@@ -33,14 +33,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class OSGIAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     private final ServiceTracker<LogService, LogService> logTracker;
     private final ServiceReference SR;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public OSGIAppender(final ServiceTracker<LogService, LogService> logTracker, final Bundle bundle) {
         this.logTracker = logTracker;
         this.SR = new RootBundleLogbackServiceReference(bundle);

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIListener.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIListener.java
@@ -52,9 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class OSGIListener {
 
     private static final Logger logger = LoggerFactory.getLogger(OSGIListener.class);

--- a/osgi/src/main/java/org/killbill/billing/osgi/api/DefaultPluginsInfoApi.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/api/DefaultPluginsInfoApi.java
@@ -43,8 +43,6 @@ import org.osgi.framework.BundleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class DefaultPluginsInfoApi implements PluginsInfoApi {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultPluginsInfoApi.class);
@@ -161,7 +159,6 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
         private final PluginState state;
         private final boolean isSelectedForStart;
 
-        @SuppressFBWarnings("EI_EXPOSE_REP2")
         public DefaultPluginInfo(final String pluginKey, final String pluginSymbolicName, final String pluginName, final String version, final PluginState state, final boolean isSelectedForStart, final Set<PluginServiceInfo> services) {
             this.pluginKey = pluginKey;
             this.pluginSymbolicName = pluginSymbolicName;
@@ -169,7 +166,7 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
             this.version = version;
             this.state = state;
             this.isSelectedForStart = isSelectedForStart;
-            this.services = services;
+            this.services = Set.copyOf(services);
         }
 
         @Override
@@ -192,10 +189,9 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
             return version;
         }
 
-        @SuppressFBWarnings("EI_EXPOSE_REP")
         @Override
         public Set<PluginServiceInfo> getServices() {
-            return services;
+            return Set.copyOf(services);
         }
 
         @Override

--- a/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
@@ -57,7 +57,6 @@ import org.skife.config.ConfigurationObjectFactory;
 
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class DefaultOSGIModule extends KillBillPlatformModuleBase {
 
@@ -68,7 +67,6 @@ public class DefaultOSGIModule extends KillBillPlatformModuleBase {
 
     private final EmbeddedDB osgiEmbeddedDB;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public DefaultOSGIModule(final KillbillConfigSource configSource,
                              final OSGIConfigProperties osgiConfigProperties,
                              final OSGIDataSourceConfig osgiDataSourceConfig,

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
@@ -33,9 +33,6 @@ import org.osgi.service.http.HttpContext;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 @Singleton
 public class DefaultHttpService implements HttpService {
 

--- a/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
@@ -29,7 +29,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -48,9 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class PluginFinder {
 
     static final String SELECTED_VERSION_LINK_NAME = "SET_DEFAULT";
@@ -99,7 +96,7 @@ public class PluginFinder {
     }
 
     public Map<String, LinkedList<PluginConfig>> getAllPlugins() {
-        return allPlugins;
+        return Map.copyOf(allPlugins);
     }
 
     public void reloadPlugins() throws PluginConfigException, IOException {
@@ -125,7 +122,6 @@ public class PluginFinder {
         return result;
     }
 
-    @SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
     private <T extends PluginConfig> void loadPluginsIfRequired(final boolean reloadPlugins) throws PluginConfigException, IOException {
         synchronized (allPlugins) {
 
@@ -142,16 +138,14 @@ public class PluginFinder {
             // Order for each plugin  based on DefaultPluginConfig sort method:
             // (order first based on SELECTED_VERSION_LINK_NAME and then decreasing version number)
             //
-            final Iterator<String> pluginNamesIterator = allPlugins.keySet().iterator();
-            while (pluginNamesIterator.hasNext()) {
-                final String pluginName = pluginNamesIterator.next();
-                final LinkedList<PluginConfig> versionsForPlugin = allPlugins.get(pluginName);
+            for (final Entry<String, LinkedList<PluginConfig>> entry : allPlugins.entrySet()) {
+                final String pluginName = entry.getKey();
+                final LinkedList<PluginConfig> versionsForPlugin = entry.getValue();
                 // If all entries were disabled or the SELECTED_VERSION_LINK_NAME was disabled we end up with nothing, it is as if the plugin did not exist
                 if (versionsForPlugin.isEmpty()) {
-                    pluginNamesIterator.remove();
+                    allPlugins.remove(pluginName);
                     continue;
                 }
-
                 Collections.sort(versionsForPlugin);
                 // Make sure first entry is set with isSelectedForStart = true
                 final PluginConfig firstValue = versionsForPlugin.removeFirst();

--- a/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
+++ b/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
@@ -31,11 +31,8 @@ import org.killbill.commons.utils.io.Files;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import static org.testng.Assert.assertEquals;
 
-@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
 public class TestPluginFinder {
 
     public static final String DEFAULT_PROPERTY_NAME = "killbill.properties";


### PR DESCRIPTION
Attempt to fix https://github.com/killbill/killbill-platform/issues/88 for `killbill-platform-osgi`. Some notes:

- Use `foreach` instead of `keySet().iterator()` [here](https://github.com/killbill/killbill-platform/compare/master...xsalefter:platform-88-killbill_platform_osgi?expand=1#diff-e621a98b4971ad3608c23494afcef5b22be45862ea7f3552ba92199503c061b8R141).

- Exclude every `EI_EXPOSE_REP` and `EI_EXPOSE_REP2` in [DefaultOSGIKillbill](https://github.com/killbill/killbill-platform/compare/master...xsalefter:platform-88-killbill_platform_osgi?expand=1#diff-2e5fda3959d83113fc7421e355dab2acd4313b0699cb427f8bb70aaeea1fc9a9R68). I have mixed feeling because if in the future we have business method, it wont be scanned, but then again I doubt we will put any business method in this class.

- Several `EI_EXPOSE_REP` that affected collections replaced by `<XXX>.copyOf()`