### PR TITLE
address spotbugs for all osgi bundles

### DIFF
--- a/osgi-bundles/bundles/eureka/pom.xml
+++ b/osgi-bundles/bundles/eureka/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <!-- http://jira.codehaus.org/browse/MRESOURCES-99 -->
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.osgi.bundles.eureka.*</osgi.private>
     </properties>
     <dependencyManagement>
@@ -46,10 +47,6 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.netflix.archaius</groupId>
             <artifactId>archaius-core</artifactId>

--- a/osgi-bundles/bundles/eureka/spotbugs-exclude.xml
+++ b/osgi-bundles/bundles/eureka/spotbugs-exclude.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.eureka.EurekaServiceRegistry" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi-bundles/bundles/eureka/src/main/java/org/killbill/billing/osgi/bundles/eureka/Activator.java
+++ b/osgi-bundles/bundles/eureka/src/main/java/org/killbill/billing/osgi/bundles/eureka/Activator.java
@@ -45,7 +45,6 @@ import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.discovery.EurekaClient;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class Activator extends KillbillActivatorBase {
 
@@ -103,7 +102,6 @@ public class Activator extends KillbillActivatorBase {
         registrar.registerService(context, ServiceDiscoveryRegistry.class, serviceRegistry, props);
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP")
     private InstanceInfo createInstanceInfo(final EurekaInstanceConfig eurekaConfig) {
         // Build the lease information to be passed to the server based on eurekaConfig
         final LeaseInfo.Builder leaseInfoBuilder = LeaseInfo.Builder.newBuilder()

--- a/osgi-bundles/bundles/eureka/src/main/java/org/killbill/billing/osgi/bundles/eureka/EurekaServiceRegistry.java
+++ b/osgi-bundles/bundles/eureka/src/main/java/org/killbill/billing/osgi/bundles/eureka/EurekaServiceRegistry.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class EurekaServiceRegistry implements ServiceDiscoveryRegistry {
 
@@ -35,9 +34,6 @@ public class EurekaServiceRegistry implements ServiceDiscoveryRegistry {
 
     private final ApplicationInfoManager applicationInfoManager;
 
-    public static final String EUREKA_SERVICE_NAME = "eureka-service";
-
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     @Inject
     public EurekaServiceRegistry(final ApplicationInfoManager applicationInfoManager) {
         this.applicationInfoManager = applicationInfoManager;

--- a/osgi-bundles/bundles/prometheus/pom.xml
+++ b/osgi-bundles/bundles/prometheus/pom.xml
@@ -29,14 +29,11 @@
     <properties>
         <!-- io.prometheus libraries have duplicated classes... -->
         <check.skip-duplicate-finder>true</check.skip-duplicate-finder>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.osgi.bundles.prometheus.*</osgi.private>
         <prometheus.version>0.15.0</prometheus.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>

--- a/osgi-bundles/bundles/prometheus/spotbugs-exclude.xml
+++ b/osgi-bundles/bundles/prometheus/spotbugs-exclude.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Or>
+            <Class name="org.killbill.billing.osgi.bundles.prometheus.KillBillCollector" />
+            <Class name="org.killbill.billing.osgi.bundles.prometheus.KillBillExporter" />
+        </Or>
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillCollector.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillCollector.java
@@ -35,7 +35,6 @@ import org.killbill.commons.metrics.api.MetricRegistry;
 import org.killbill.commons.metrics.api.Snapshot;
 import org.killbill.commons.metrics.api.Timer;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.client.Collector;
 
 // Inspired from io.prometheus.client.dropwizard.DropwizardExports (Apache-2.0 License)
@@ -43,7 +42,6 @@ public class KillBillCollector extends Collector {
 
     private final MetricRegistry registry;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public KillBillCollector(final MetricRegistry registry) {
         this.registry = registry;
     }

--- a/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillExporter.java
+++ b/osgi-bundles/bundles/prometheus/src/main/java/org/killbill/billing/osgi/bundles/prometheus/KillBillExporter.java
@@ -31,7 +31,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Predicate;
 import io.prometheus.client.SampleNameFilter;
@@ -44,7 +43,6 @@ public class KillBillExporter {
     private final CollectorRegistry registry;
     private final Predicate<String> sampleNameFilter;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public KillBillExporter(final CollectorRegistry registry, final Predicate<String> sampleNameFilter) {
         this.registry = registry;
         this.sampleNameFilter = sampleNameFilter;

--- a/osgi-bundles/libs/killbill/pom.xml
+++ b/osgi-bundles/libs/killbill/pom.xml
@@ -28,11 +28,10 @@
     <artifactId>killbill-platform-osgi-bundles-lib-killbill</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-osgi-bundles-lib-killbill</name>
+    <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+    </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>

--- a/osgi-bundles/libs/killbill/spotbugs-exclude.xml
+++ b/osgi-bundles/libs/killbill/spotbugs-exclude.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.libs.killbill.KillbillServiceListener" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillActivatorBase.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillActivatorBase.java
@@ -33,8 +33,6 @@ import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public abstract class KillbillActivatorBase implements BundleActivator {
 
     private static final Logger logger = LoggerFactory.getLogger(KillbillActivatorBase.class);
@@ -61,7 +59,6 @@ public abstract class KillbillActivatorBase implements BundleActivator {
 
     private ScheduledFuture<?> restartFuture = null;
 
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     @Override
     public void start(final BundleContext context) throws Exception {
         // Keep it for now for backward compatibility purposes with existing plugins

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillServiceListener.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/KillbillServiceListener.java
@@ -25,8 +25,6 @@ import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceListener;
 import org.osgi.framework.ServiceReference;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class KillbillServiceListener implements ServiceListener {
 
     private final BundleContext context;
@@ -47,7 +45,6 @@ public class KillbillServiceListener implements ServiceListener {
         return killbillServiceListener;
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public KillbillServiceListener(final BundleContext context, final KillbillServiceListenerCallback killbillServiceListenerCallback) {
         this.context = context;
         this.killbillServiceListenerCallback = killbillServiceListenerCallback;

--- a/osgi-bundles/tests/beatrix/pom.xml
+++ b/osgi-bundles/tests/beatrix/pom.xml
@@ -29,13 +29,10 @@
     <packaging>bundle</packaging>
     <name>killbill-platform-osgi-bundles-test-beatrix</name>
     <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.osgi.bundles.test.*</osgi.private>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>

--- a/osgi-bundles/tests/beatrix/spotbugs-exclude.xml
+++ b/osgi-bundles/tests/beatrix/spotbugs-exclude.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.test.TestPaymentPluginApi" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi-bundles/tests/beatrix/src/main/java/org/killbill/billing/osgi/bundles/test/TestPaymentPluginApi.java
+++ b/osgi-bundles/tests/beatrix/src/main/java/org/killbill/billing/osgi/bundles/test/TestPaymentPluginApi.java
@@ -44,13 +44,10 @@ import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.entity.Pagination;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class TestPaymentPluginApi implements PaymentPluginApi {
 
     private final TestDao testDao;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public TestPaymentPluginApi(final TestDao testDao) {
         this.testDao = testDao;
     }

--- a/osgi-bundles/tests/payment/pom.xml
+++ b/osgi-bundles/tests/payment/pom.xml
@@ -29,13 +29,10 @@
     <packaging>bundle</packaging>
     <name>killbill-platform-osgi-bundles-test-payment</name>
     <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.osgi.bundles.test.*</osgi.private>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>

--- a/osgi-bundles/tests/payment/spotbugs-exclude.xml
+++ b/osgi-bundles/tests/payment/spotbugs-exclude.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.test.TestPaymentPluginApi" />
+        <Or>
+            <Method name="setPaymentPluginApiExceptionOnNextCalls"/>
+            <Method name="setPaymentRuntimeExceptionOnNextCalls"/>
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi-bundles/tests/payment/src/main/java/org/killbill/billing/osgi/bundles/test/TestPaymentPluginApi.java
+++ b/osgi-bundles/tests/payment/src/main/java/org/killbill/billing/osgi/bundles/test/TestPaymentPluginApi.java
@@ -42,8 +42,6 @@ import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.entity.Pagination;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class TestPaymentPluginApi implements PaymentPluginApiWithTestControl {
 
     private PaymentPluginApiException paymentPluginApiExceptionOnNextCalls;
@@ -278,14 +276,12 @@ public class TestPaymentPluginApi implements PaymentPluginApiWithTestControl {
         }
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     @Override
     public void setPaymentPluginApiExceptionOnNextCalls(final PaymentPluginApiException e) {
         resetToNormalBehavior();
         paymentPluginApiExceptionOnNextCalls = e;
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     @Override
     public void setPaymentRuntimeExceptionOnNextCalls(final RuntimeException e) {
         resetToNormalBehavior();

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -28,6 +28,9 @@
     <artifactId>killbill-platform-osgi</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-osgi</name>
+    <properties>
+        <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -56,10 +59,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/osgi/spotbugs-exclude.xml
+++ b/osgi/spotbugs-exclude.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2023 Equinix, Inc
+  ~ Copyright 2014-2023 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+                            https://raw.githubusercontent.com/spotbugs/spotbugs/4.6.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- justification: Nothing we can do about this, because:
+         1. Copying instance is not needed/lead to error logic, or
+         2. Refactor will nearly impossible or need too many resources -->
+    <Match>
+        <Class name="org.killbill.billing.osgi.glue.DefaultOSGIModule" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.KillbillEventRetriableBusHandler" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.OSGIAppender" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.OSGIListener" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.KillbillActivator" />
+        <Or>
+            <Method name="&lt;init&gt;"/>
+            <Method name="start"/>
+        </Or>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.api.DefaultPluginsInfoApi" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.DefaultOSGIService" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <!-- This class is just getter-setter. Listing all methods here is kinda pointless -->
+        <Class name="org.killbill.billing.osgi.DefaultOSGIKillbill" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.osgi.http.DefaultHttpService" />
+        <Method name="&lt;init&gt;"/>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+</FindBugsFilter>

--- a/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/BundleRegistry.java
@@ -38,8 +38,6 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class BundleRegistry {
 
     private static final Logger log = LoggerFactory.getLogger(BundleRegistry.class);
@@ -168,7 +166,7 @@ public class BundleRegistry {
 
         public BundleWithMetadata(final BundleWithConfig bundleWithConfig) {
             super(bundleWithConfig.getBundle(), bundleWithConfig.getConfig());
-            serviceNames = new HashSet<PluginServiceInfo>();
+            serviceNames = new HashSet<>();
         }
 
         public String getPluginName() {
@@ -187,9 +185,8 @@ public class BundleRegistry {
             serviceNames.remove(new DefaultPluginServiceInfo(serviceTypeName, registrationName));
         }
 
-        @SuppressFBWarnings("EI_EXPOSE_REP")
         public Set<PluginServiceInfo> getServiceNames() {
-            return serviceNames;
+            return new HashSet<>(serviceNames);
         }
     }
 

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIKillbill.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIKillbill.java
@@ -45,9 +45,6 @@ import org.killbill.billing.util.api.RecordIdApi;
 import org.killbill.billing.util.api.TagUserApi;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class DefaultOSGIKillbill implements OSGIKillbill {
 
     private AccountUserApi accountUserApi;

--- a/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/DefaultOSGIService.java
@@ -41,11 +41,7 @@ import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class DefaultOSGIService implements OSGIService {
-
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultOSGIService.class);
 
@@ -131,9 +127,8 @@ public class DefaultOSGIService implements OSGIService {
         }
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP")
     public List<BundleWithConfig> getInstalledBundles() {
-        return installedBundles;
+        return List.copyOf(installedBundles);
     }
 
     private Framework createAndInitFramework() throws BundleException {

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
@@ -67,9 +67,6 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class KillbillActivator implements BundleActivator, AllServiceListener {
 
     static final int PLUGIN_NAME_MAX_LENGTH = 40;
@@ -180,7 +177,7 @@ public class KillbillActivator implements BundleActivator, AllServiceListener {
     @Override
     public void start(final BundleContext context) throws Exception {
         this.context = context;
-        final Dictionary<String, String> props = new Hashtable<String, String>();
+        final Dictionary<String, String> props = new Hashtable<>();
         props.put(OSGIPluginProperties.PLUGIN_NAME_PROP, "killbill");
 
         // Forward all core log entries to the OSGI LogService, so that plugins have access to them

--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillEventRetriableBusHandler.java
@@ -55,10 +55,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 // Needs to be injected for the lifecycle logic
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class KillbillEventRetriableBusHandler extends RetryableService implements KillbillEventRetriableBusHandlerService {
 
     private final Logger logger = LoggerFactory.getLogger(KillbillEventRetriableBusHandler.class);

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
@@ -33,14 +33,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class OSGIAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     private final ServiceTracker<LogService, LogService> logTracker;
     private final ServiceReference SR;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public OSGIAppender(final ServiceTracker<LogService, LogService> logTracker, final Bundle bundle) {
         this.logTracker = logTracker;
         this.SR = new RootBundleLogbackServiceReference(bundle);

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIListener.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIListener.java
@@ -52,9 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class OSGIListener {
 
     private static final Logger logger = LoggerFactory.getLogger(OSGIListener.class);

--- a/osgi/src/main/java/org/killbill/billing/osgi/api/DefaultPluginsInfoApi.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/api/DefaultPluginsInfoApi.java
@@ -43,8 +43,6 @@ import org.osgi.framework.BundleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class DefaultPluginsInfoApi implements PluginsInfoApi {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultPluginsInfoApi.class);
@@ -161,7 +159,6 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
         private final PluginState state;
         private final boolean isSelectedForStart;
 
-        @SuppressFBWarnings("EI_EXPOSE_REP2")
         public DefaultPluginInfo(final String pluginKey, final String pluginSymbolicName, final String pluginName, final String version, final PluginState state, final boolean isSelectedForStart, final Set<PluginServiceInfo> services) {
             this.pluginKey = pluginKey;
             this.pluginSymbolicName = pluginSymbolicName;
@@ -169,7 +166,7 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
             this.version = version;
             this.state = state;
             this.isSelectedForStart = isSelectedForStart;
-            this.services = services;
+            this.services = Set.copyOf(services);
         }
 
         @Override
@@ -192,10 +189,9 @@ public class DefaultPluginsInfoApi implements PluginsInfoApi {
             return version;
         }
 
-        @SuppressFBWarnings("EI_EXPOSE_REP")
         @Override
         public Set<PluginServiceInfo> getServices() {
-            return services;
+            return Set.copyOf(services);
         }
 
         @Override

--- a/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/glue/DefaultOSGIModule.java
@@ -57,7 +57,6 @@ import org.skife.config.ConfigurationObjectFactory;
 
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class DefaultOSGIModule extends KillBillPlatformModuleBase {
 
@@ -68,7 +67,6 @@ public class DefaultOSGIModule extends KillBillPlatformModuleBase {
 
     private final EmbeddedDB osgiEmbeddedDB;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public DefaultOSGIModule(final KillbillConfigSource configSource,
                              final OSGIConfigProperties osgiConfigProperties,
                              final OSGIDataSourceConfig osgiDataSourceConfig,

--- a/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/http/DefaultHttpService.java
@@ -33,9 +33,6 @@ import org.osgi.service.http.HttpContext;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings("EI_EXPOSE_REP")
 @Singleton
 public class DefaultHttpService implements HttpService {
 

--- a/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
@@ -29,7 +29,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -48,9 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings("EI_EXPOSE_REP")
 public class PluginFinder {
 
     static final String SELECTED_VERSION_LINK_NAME = "SET_DEFAULT";
@@ -99,7 +96,7 @@ public class PluginFinder {
     }
 
     public Map<String, LinkedList<PluginConfig>> getAllPlugins() {
-        return allPlugins;
+        return Map.copyOf(allPlugins);
     }
 
     public void reloadPlugins() throws PluginConfigException, IOException {
@@ -125,7 +122,6 @@ public class PluginFinder {
         return result;
     }
 
-    @SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
     private <T extends PluginConfig> void loadPluginsIfRequired(final boolean reloadPlugins) throws PluginConfigException, IOException {
         synchronized (allPlugins) {
 
@@ -142,16 +138,14 @@ public class PluginFinder {
             // Order for each plugin  based on DefaultPluginConfig sort method:
             // (order first based on SELECTED_VERSION_LINK_NAME and then decreasing version number)
             //
-            final Iterator<String> pluginNamesIterator = allPlugins.keySet().iterator();
-            while (pluginNamesIterator.hasNext()) {
-                final String pluginName = pluginNamesIterator.next();
-                final LinkedList<PluginConfig> versionsForPlugin = allPlugins.get(pluginName);
+            for (final Entry<String, LinkedList<PluginConfig>> entry : allPlugins.entrySet()) {
+                final String pluginName = entry.getKey();
+                final LinkedList<PluginConfig> versionsForPlugin = entry.getValue();
                 // If all entries were disabled or the SELECTED_VERSION_LINK_NAME was disabled we end up with nothing, it is as if the plugin did not exist
                 if (versionsForPlugin.isEmpty()) {
-                    pluginNamesIterator.remove();
+                    allPlugins.remove(pluginName);
                     continue;
                 }
-
                 Collections.sort(versionsForPlugin);
                 // Make sure first entry is set with isSelectedForStart = true
                 final PluginConfig firstValue = versionsForPlugin.removeFirst();

--- a/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
+++ b/osgi/src/test/java/org/killbill/billing/osgi/pluginconf/TestPluginFinder.java
@@ -31,11 +31,8 @@ import org.killbill.commons.utils.io.Files;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import static org.testng.Assert.assertEquals;
 
-@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
 public class TestPluginFinder {
 
     public static final String DEFAULT_PROPERTY_NAME = "killbill.properties";


### PR DESCRIPTION
Attempt to fix https://github.com/killbill/killbill-platform/issues/88. applied modules:
- `osgi-bundles-eureka`
- `osgi-bundles-lib-killbill`
- `osgi-bundles-prometheus`
- `osgi-bundles-test-beatrix`
- `osgi-bundles-test-payment`

No code changes other than removing annotations. The only reason I keep doing this because to keep this the same as other modules and projects (non `osgi-bundles` modules use XML. `killbill-commons` use XML).