### PR TITLE
Changes for InvoiceFormatterFactory

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/KillbillActivator.java
@@ -38,6 +38,7 @@ import org.killbill.billing.catalog.plugin.api.CatalogPluginApi;
 import org.killbill.billing.control.plugin.api.PaymentControlPluginApi;
 import org.killbill.billing.currency.plugin.api.CurrencyPluginApi;
 import org.killbill.billing.entitlement.plugin.api.EntitlementPluginApi;
+import org.killbill.billing.invoice.plugin.api.InvoiceFormatterFactory;
 import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.osgi.api.Healthcheck;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
@@ -137,6 +138,11 @@ public class KillbillActivator implements BundleActivator, AllServiceListener {
     @Inject
     public void addCurrencyPluginApiOSGIServiceRegistration(@Nullable final OSGIServiceRegistration<CurrencyPluginApi> currencyProviderPluginRegistry) {
         allRegistrationHandlers.add(currencyProviderPluginRegistry);
+    }
+
+    @Inject
+    public void addInvoiceFormatterFactoryOSGIServiceRegistration(@Nullable final OSGIServiceRegistration<InvoiceFormatterFactory> invoiceFormatterFactoryRegistry) {
+        allRegistrationHandlers.add(invoiceFormatterFactoryRegistry);
     }
 
     @Inject

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -28,5 +28,5 @@
     <artifactId>killbill-platform-api</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-api</name>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -278,8 +278,8 @@
                         <phase>initialize</phase>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar" />
-                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar" />
+                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar"/>
                             </tasks>
                         </configuration>
                     </execution>

--- a/platform-test/src/test/java/org/killbill/billing/beatrix/integration/osgi/glue/TestIntegrationModule.java
+++ b/platform-test/src/test/java/org/killbill/billing/beatrix/integration/osgi/glue/TestIntegrationModule.java
@@ -33,6 +33,7 @@ import org.killbill.billing.entitlement.api.EntitlementApi;
 import org.killbill.billing.entitlement.api.SubscriptionApi;
 import org.killbill.billing.entitlement.plugin.api.EntitlementPluginApi;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
+import org.killbill.billing.invoice.plugin.api.InvoiceFormatterFactory;
 import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.osgi.api.Healthcheck;
 import org.killbill.billing.osgi.api.OSGIServiceDescriptor;
@@ -116,6 +117,7 @@ public class TestIntegrationModule extends KillBillPlatformModuleBase {
         bind(new TypeLiteral<OSGIServiceRegistration<PaymentPluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(PaymentPluginApi.class));
         bind(new TypeLiteral<OSGIServiceRegistration<CurrencyPluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(CurrencyPluginApi.class));
         bind(new TypeLiteral<OSGIServiceRegistration<InvoicePluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(InvoicePluginApi.class));
+        bind(new TypeLiteral<OSGIServiceRegistration<InvoiceFormatterFactory>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(InvoiceFormatterFactory.class));
         bind(new TypeLiteral<OSGIServiceRegistration<PaymentControlPluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(PaymentControlPluginApi.class));
         bind(new TypeLiteral<OSGIServiceRegistration<CatalogPluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(CatalogPluginApi.class));
         bind(new TypeLiteral<OSGIServiceRegistration<EntitlementPluginApi>>() {}).toInstance(new TestPlatformPaymentProviderPluginRegistry<>(EntitlementPluginApi.class));
@@ -134,6 +136,8 @@ public class TestIntegrationModule extends KillBillPlatformModuleBase {
         public TestPlatformPaymentProviderPluginRegistry(final Class<T> serviceType) {
             this.serviceType = serviceType;
         }
+
+
 
         @Override
         public void registerService(final OSGIServiceDescriptor desc, final T service) {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.24</version>
+        <version>0.146.28</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.41.7-SNAPSHOT</version>


### PR DESCRIPTION
- Updated oss-parent version to `0.146.28` to point to the latest `killbill-plugin-api` (that has the `InvoiceFormatteFactory` interface
- Code changes for `InvoiceFormatterFactory`.