### PR TITLE
Fix for ci failure

### DIFF
--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/UrlResolverFactory.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/UrlResolverFactory.java
@@ -39,7 +39,7 @@ public class UrlResolverFactory {
     // add something like "/content/repositories" at this point.
     private String getValidUrlIfSonatype(final String url) {
         return url.contains("oss.sonatype.org") ?
-               String.format("%s/content/repositories/%s", kpmProperties.getNexusUrl(), kpmProperties.getNexusRepository()) :
+               String.format("%scontent/repositories/%s", kpmProperties.getNexusUrl(), kpmProperties.getNexusRepository()) :
                url;
     }
 
@@ -56,7 +56,7 @@ public class UrlResolverFactory {
         final AuthenticationMethod authMethod = AuthenticationMethod.valueOf(kpmProperties.getNexusAuthMethod().toUpperCase());
         switch (authMethod) {
             case NONE:
-                String baseUrl = getValidUrlIfSonatype(kpmProperties.getNexusUrl() + "/" + kpmProperties.getNexusRepository());
+                String baseUrl = getValidUrlIfSonatype(kpmProperties.getNexusUrl()  + kpmProperties.getNexusRepository());
                 return new NoneUriResolver(baseUrl);
 
             case BASIC:

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginManager.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginManager.java
@@ -61,8 +61,8 @@ public class TestDefaultPluginManager {
     @Test(groups = "slow")
     public void testGetAvailablePlugins() {
         // Get plugin info from actual, default, killbill plugins_directory.yml. See DefaultPluginsDirectoryDAO
-        GetAvailablePluginsModel result = pluginManager.getAvailablePlugins("0.18.0", true);
-        Assert.assertEquals(result.getKillbillArtifactsVersion().getKillbill(), "0.18.0");
+        GetAvailablePluginsModel result = pluginManager.getAvailablePlugins("0.24.0", true);
+        Assert.assertEquals(result.getKillbillArtifactsVersion().getKillbill(), "0.24.0");
         Assert.assertFalse(result.getAvailablePlugins().isEmpty());
 
         try {


### PR DESCRIPTION
On merging a recent PR, [CI has started failing](https://github.com/killbill/killbill-platform/actions/runs/8056539700/job/22013472540#step:7:3019). The [TestDefaultPluginManager.testGetAvailablePlugins](https://github.com/killbill/killbill-platform/blob/faf0f2a65d9962298e41da8677bbbf0071a661bc/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginManager.java#L62C17-L62C40) fails. On investigating this further, it was found that the issue occurs due to the extra `/` in the sonatype URL. Not sure why the issue has surfaced only now. This PR attempts to fix this issue.