### PR TITLE
fix maven release problem

### DIFF
--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -28,5 +28,5 @@
     <artifactId>killbill-platform-api</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-api</name>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -278,8 +278,8 @@
                         <phase>initialize</phase>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar" />
-                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar" />
+                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar"/>
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The problem [discussed here](https://killbillio.slack.com/archives/C02C15Z92PJ/p1684867469368259?thread_ts=1684787234.471059&cid=C02C15Z92PJ). From Pierre:

> There is this annoying bug by the maven release plugin which introduces whitespace changes when it makes a release. I suspect if you run mvn install locally, you will see whitespace changes. You need to commit them before being able to do the release