### PR TITLE
osgi: Add additional joda packages to be exported by system bundle

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -97,7 +97,7 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              //
              // We also add the dependencies from own set of APIs and some osgi compendium thingies...
              //
-             "org.joda.time;org.joda.time.format;version=2.9," +
+             "org.joda.time;org.joda.time.format;org.joda.time.base;org.joda.time.chrono;org.joda.time.tz;org.joda.time.convert;org.joda.time.field;version=2.12," +
              "org.apache.shiro;org.apache.shiro.subject;org.apache.shiro.util;version=1.3," +
              // Let the world know the System bundle exposes the requirement (&(osgi.wiring.package=org.slf4j)(version>=1.7.0)(!(version>=2.0.0)))
              "org.slf4j;version=1.7.2," +


### PR DESCRIPTION
While debugging a plugin, I encountered the following exception and had to configure the system add the missing package using `org.killbill.osgi.system.bundle.export.packages.extra=org.joda.time.base;resolution:=optional;version=2.12.5`

```
2024-12-05T23:13:46,870+0000 lvl='ERROR', log='LoggingExecutor', th='notifications-th', xff='', rId='', tok='', aRId='', tRId='', Thread[notifications-th,5,main] ended with an exception java.lang.NoClassDefFoundError: org/joda/time/base/AbstractInstant
```
