### PR TITLE
Fix plugin removal from BundleRegistry on uninstallation

### DIFF
--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginManager.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultPluginManager.java
@@ -101,10 +101,13 @@ public class DefaultPluginManager implements PluginManager {
                                         final String pluginVersion) {
         try {
             logger.info("Notifying Kill Bill: state='{}', pluginKey='{}', pluginVersion={}", newState, pluginKey, pluginVersion);
+
             killbillApi.getSecurityApi().login(adminUsername, adminPassword);
+
+            final PluginNamingResolver pluginNamingResolver = PluginNamingResolver.of(pluginKey);
             killbillApi.getPluginsInfoApi().notifyOfStateChanged(newState,
                                                                  pluginKey,
-                                                                 null, // Not needed
+                                                                 pluginNamingResolver.getPluginName(),
                                                                  pluginVersion,
                                                                  null /* Unused */);
         } finally {


### PR DESCRIPTION
When a plugin is uninstalled, it is not removed from the BundleRegistry due to a missing pluginName. This causes an IllegalStateException when attempting to install another plugin with the same pluginKey.

Update the notifyFileSystemChange() method to ensure pluginName is passed correctly, ensuring the plugin is removed from the registry.