### PR TITLE
Handled a scenario where plugin_identifiers.json is empty or contains only whitespace by replacing it with a valid JSON structure instead of throwing an IOException

### DIFF
--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestFileBasedPluginIdentifiersDAO.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestFileBasedPluginIdentifiersDAO.java
@@ -17,15 +17,19 @@
 
 package org.killbill.billing.osgi.bundles.kpm.impl;
 
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+
+import org.killbill.billing.osgi.bundles.kpm.KPMPluginException;
 import org.killbill.billing.osgi.bundles.kpm.KpmProperties;
+import org.killbill.billing.osgi.bundles.kpm.PluginIdentifiersDAO;
 import org.killbill.billing.osgi.bundles.kpm.PluginIdentifiersDAO.PluginIdentifierModel;
 import org.killbill.billing.osgi.bundles.kpm.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 public class TestFileBasedPluginIdentifiersDAO {
 
@@ -58,6 +62,26 @@ public class TestFileBasedPluginIdentifiersDAO {
         Assert.assertNotNull(pluginIdentifierModel);
         Assert.assertEquals(pluginIdentifierModel.getPluginName(), pluginNamingResolver.getPluginName());
         Assert.assertEquals(pluginIdentifierModel.getVersion(), pluginNamingResolver.getPluginVersion());
+    }
+
+    @Test(groups = "fast", expectedExceptions = KPMPluginException.class)
+    void testLoadFileContentInvalidJson() throws IOException {
+        try (final FileWriter writer = new FileWriter(pluginIdentifiersDAO.file, false)) {
+            writer.write("INVALID_JSON_CONTENT");
+        }
+
+        pluginIdentifiersDAO.loadFileContent();
+    }
+
+    @Test(groups = "fast")
+    void testLoadFileContentEmptyJson() throws IOException {
+        try (final FileWriter writer = new FileWriter(pluginIdentifiersDAO.file)) {
+            writer.write(" ");
+        }
+
+        final Map<String, PluginIdentifiersDAO.PluginIdentifierModel> pluginIdentifierModelMap = pluginIdentifiersDAO.loadFileContent();
+
+        Assert.assertTrue(pluginIdentifierModelMap.isEmpty());
     }
 
     @Test(groups = "fast")

--- a/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/pluginconf/PluginFinder.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -169,11 +170,16 @@ public class PluginFinder {
 
         try {
             identifiers.clear();
-            final Map<String, PluginIdentifier> map = mapper.readValue(identifierFile, new TypeReference<Map<String, PluginIdentifier>>() {});
+
+            if (identifierFile.length() == 0 || Files.readString(identifierFile.toPath()).isBlank()) {
+                logger.info("File {} is missing or empty. Initializing with an empty JSON object", identifierFile.getAbsolutePath());
+
+                mapper.writeValue(identifierFile, new HashMap<>());
+            }
+            final Map<String, PluginIdentifier> map = mapper.readValue(identifierFile, new TypeReference<>() {});
             identifiers.putAll(map);
         } catch (final IOException e) {
             logger.warn("Exception when parsing " + IDENTIFIERS_FILE_NAME + ":", e);
-            return;
         }
     }
 


### PR DESCRIPTION
PR for https://github.com/killbill/killbill-platform/issues/174