### PR TITLE
Enhanced logging in KPM package and added logger name to SSE endpoint logs.

### DIFF
--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLogWriter.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/KillbillLogWriter.java
@@ -52,8 +52,10 @@ public class KillbillLogWriter implements BundleListener, FrameworkListener, Ser
     public void log(final ServiceReference serviceReference, final int level, final String message, final Throwable exception) {
         final Bundle bundle = serviceReference == null ? null : serviceReference.getBundle();
 
+        final String loggerName = message.split("; ")[0];
+
         // Forward the log to HTTP consumers
-        logEntriesManager.recordEvent(new LogEntryJson(bundle, level, message, exception));
+        logEntriesManager.recordEvent(new LogEntryJson(bundle, level, loggerName, message, exception));
 
         if (serviceReference != null && "true".equals(serviceReference.getProperty("KILL_BILL_ROOT_LOGGING"))) {
             // LogEntry comes from Logback already (see OSGIAppender), ignore

--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/LogEntryJson.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/LogEntryJson.java
@@ -34,10 +34,11 @@ public class LogEntryJson {
     private final UUID id;
     private final String level;
     private final String name;
+    private final String logger;
     private final String message;
     private final Long time;
 
-    public LogEntryJson(final Bundle bundle, final int intLevel, final String message, final Throwable exception) {
+    public LogEntryJson(final Bundle bundle, final int intLevel, final String loggerName, final String message, final Throwable exception) {
         id = UUID.randomUUID();
 
         if (intLevel == LogService.LOG_ERROR) {
@@ -64,8 +65,13 @@ public class LogEntryJson {
             name = bundle.getSymbolicName();
         }
 
+        this.logger = loggerName;
         this.message = message;
         this.time = System.currentTimeMillis();
+    }
+
+    public String getLogger() {
+        return logger;
     }
 
     public UUID getId() {
@@ -98,6 +104,7 @@ public class LogEntryJson {
             sb.append("\"id\":\"").append(id).append("\"");
             sb.append(", \"level\":\"").append(level).append("\"");
             sb.append(", \"name\":\"").append(name).append("\"");
+            sb.append(", \"logger\":\"").append(logger).append("\"");
             sb.append(", \"message\":\"").append(message).append("\"");
             sb.append(", \"time\":\"").append(time).append("\"");
             sb.append('}');

--- a/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/OSGIAppender.java
@@ -81,7 +81,11 @@ public class OSGIAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             }
         }
 
-        logService.log(SR, level, eventObject.getFormattedMessage(), t);
+        final String loggerName = eventObject.getLoggerName();
+
+        final String msg = loggerName + "; " + eventObject.getFormattedMessage();
+
+        logService.log(SR, level, msg, t);
     }
 
     private static final class RootBundleLogbackServiceReference implements ServiceReference {


### PR DESCRIPTION
Sample SSE endpoint log:

```
id:c525617e-81b3-4f4c-95ee-ed45d671a86e
data:{"id":"c525617e-81b3-4f4c-95ee-ed45d671a86e","level":"DEBUG","name":"org.apache.felix.framework","logger":"org.killbill.billing.util.glue.KillbillApiAopModule","message":"org.killbill.billing.util.glue.KillbillApiAopModule; Entering API call public org.killbill.billing.util.nodes.NodeInfo org.killbill.billing.util.nodes.DefaultKillbillNodesApi.getCurrentNodeInfo(), arguments: []","time":1741073882142}

id:163f0269-7840-48cc-bc8c-658387e57eaa
data:{"id":"163f0269-7840-48cc-bc8c-658387e57eaa","level":"DEBUG","name":"org.apache.felix.framework","logger":"org.killbill.billing.util.entity.dao.DBRouterUntyped","message":"org.killbill.billing.util.entity.dao.DBRouterUntyped; RO DBI requested, but thread state is RW_ONLY, using RW DBI","time":1741073882142}

id:d3d4b2c5-61c3-4d63-96cc-907419832469
data:{"id":"d3d4b2c5-61c3-4d63-96cc-907419832469","level":"DEBUG","name":"org.apache.felix.framework","logger":"org.killbill.commons.jdbi.guice.DBIProvider","message":"org.killbill.commons.jdbi.guice.DBIProvider; Handle [org.skife.jdbi.v2.BasicHandle@7460dd36] obtained in 0 millis","time":1741073882143}

id:c44e8d76-cf97-49cb-9a46-d8b64cad8670
data:{"id":"c44e8d76-cf97-49cb-9a46-d8b64cad8670","level":"DEBUG","name":"org.apache.felix.framework","logger":"org.mariadb.jdbc.client.impl.StandardClient","message":"org.mariadb.jdbc.client.impl.StandardClient; execute query: set autocommit=0","time":1741073882143}

id:537b1803-fa0f-450b-a932-b81caf8f3e12
data:{"id":"537b1803-fa0f-450b-a932-b81caf8f3e12","level":"DEBUG","name":"org.apache.felix.framework","logger":"org.mariadb.jdbc.message.server.OkPacket","message":"org.mariadb.jdbc.message.server.OkPacket; System variable change:  autocommit = OFF","time":1741073882143}

```