### PR TITLE
Expose runtime config properties by source

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -110,9 +110,5 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>ssm</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -110,5 +110,9 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -128,6 +129,31 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
         RuntimeConfigRegistry.getAll().forEach((key, value) -> {
             if (!result.containsKey(key)) {
                 result.setProperty(key, value);
+            }
+        });
+
+        return result;
+    }
+
+    @Override
+    public Map<String, Map<String, String>> getPropertiesBySource() {
+        final Map<String, Map<String, String>> result = new HashMap<>();
+        final Map<String, String> systemProps = new HashMap<>();
+
+        properties.stringPropertyNames().forEach(key -> systemProps.put(key, properties.getProperty(key)));
+        result.put("SystemProperties", systemProps);
+
+        final Map<String, Map<String, String>> runtimeBySource = RuntimeConfigRegistry.getAllBySource();
+        runtimeBySource.forEach((source, props) -> {
+            final Map<String, String> filteredProps = new HashMap<>();
+            props.forEach((key, value) -> {
+                if (!systemProps.containsKey(key)) {
+                    filteredProps.put(key, value);
+                }
+            });
+
+            if (!filteredProps.isEmpty()) {
+                result.put(source, filteredProps);
             }
         });
 

--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -192,7 +192,7 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
             }
         }
 
-        final Properties systemProperties = new Properties(System.getProperties());
+        final Properties systemProperties = System.getProperties();
 
         runtimeConfigBySource.put("SystemProperties", propertiesToMap(systemProperties));
 

--- a/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
+++ b/base/src/main/java/org/killbill/billing/platform/config/DefaultKillbillConfigSource.java
@@ -21,6 +21,7 @@ package org.killbill.billing.platform.config;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -166,7 +167,8 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
 
         runtimeConfigBySource.putAll(runtimeBySource);
 
-        return runtimeConfigBySource;
+        // Returning a shallow copy to satisfy SpotBugs (EI_EXPOSE_REP).
+        return new HashMap<>(runtimeConfigBySource);
     }
 
     private Properties loadPropertiesFromFileOrSystemProperties() {
@@ -382,7 +384,12 @@ public class DefaultKillbillConfigSource implements KillbillConfigSource, OSGICo
             path = path.substring("file://".length());
         }
 
-        return Paths.get(path).getFileName().toString();
+        final Path fileName = Paths.get(path).getFileName();
+        if (fileName == null) {
+            return "unknown.properties";
+        }
+
+        return fileName.toString();
     }
 
     private Map<String, String> propertiesToMap(final Properties props) {

--- a/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
@@ -81,7 +81,7 @@ public class TestDefaultKillbillConfigSource {
         Assert.assertNotNull(propsBySource);
         Assert.assertFalse(propsBySource.isEmpty());
 
-        final Map<String, String> defaultProps = propsBySource.get("SystemProperties");
+        final Map<String, String> defaultProps = propsBySource.get("ExtraDefaultProperties");
         Assert.assertNotNull(defaultProps);
         Assert.assertEquals(defaultProps.get("org.killbill.dao.user"), "root");
         Assert.assertEquals(defaultProps.get("org.killbill.dao.password"), "password");

--- a/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
+++ b/base/src/test/java/org/killbill/billing/platform/config/TestDefaultKillbillConfigSource.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.testng.Assert;
 
 import static org.killbill.billing.platform.config.DefaultKillbillConfigSource.ENVIRONMENT_VARIABLE_PREFIX;
 
@@ -66,6 +66,25 @@ public class TestDefaultKillbillConfigSource {
         Assert.assertNotNull(configSource.getProperties());
         Assert.assertNotEquals(configSource.getProperties().size(), 0);
         Assert.assertEquals(configSource.getProperties().getProperty("1"), "A");
+    }
+
+    @Test(groups = "fast")
+    public void testGetPropertiesBySource() throws URISyntaxException, IOException {
+        final Map<String, String> configuration = new HashMap<>();
+        configuration.put("org.killbill.dao.user", "root");
+        configuration.put("org.killbill.dao.password", "password");
+
+        final OSGIConfigProperties configSource = new DefaultKillbillConfigSource(null, configuration);
+
+        final Map<String, Map<String, String>> propsBySource = configSource.getPropertiesBySource();
+
+        Assert.assertNotNull(propsBySource);
+        Assert.assertFalse(propsBySource.isEmpty());
+
+        final Map<String, String> defaultProps = propsBySource.get("SystemProperties");
+        Assert.assertNotNull(defaultProps);
+        Assert.assertEquals(defaultProps.get("org.killbill.dao.user"), "root");
+        Assert.assertEquals(defaultProps.get("org.killbill.dao.password"), "password");
     }
 
     @Test(groups = "fast")

--- a/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIConfigProperties.java
+++ b/osgi-api/src/main/java/org/killbill/billing/osgi/api/OSGIConfigProperties.java
@@ -19,6 +19,7 @@
 
 package org.killbill.billing.osgi.api;
 
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -28,13 +29,26 @@ import java.util.Properties;
 public interface OSGIConfigProperties {
 
     /**
+     * Retrieves the value of the given property.
+     *
      * @param propertyName the system property name
      * @return the value of the property
      */
     public String getString(final String propertyName);
 
     /**
-     * @return all knows system properties (for the JVM)
+     * Returns all runtime resolved properties as a flat {@link Properties} object.
+     *
+     * @return all known configuration properties
      */
     public Properties getProperties();
+
+    /**
+     * Returns all runtime resolved properties grouped by their respective source.
+     * Each key in the outer map represents the source name (e.g., "SystemProperties", "KillbillServerConfig", "CatalogConfig"),
+     * and the corresponding value is a map of property names to values loaded from that source.
+     *
+     * @return a map of configuration sources to their respective key-value property sets.
+     */
+    public Map<String, Map<String, String>> getPropertiesBySource();
 }

--- a/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/OSGIConfigPropertiesService.java
+++ b/osgi-bundles/libs/killbill/src/main/java/org/killbill/billing/osgi/libs/killbill/OSGIConfigPropertiesService.java
@@ -19,6 +19,7 @@
 
 package org.killbill.billing.osgi.libs.killbill;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.killbill.billing.osgi.api.OSGIConfigProperties;
@@ -56,6 +57,16 @@ public class OSGIConfigPropertiesService extends OSGIKillbillLibraryBase impleme
             @Override
             public Properties executeWithService(final OSGIConfigProperties service) {
                 return service.getProperties();
+            }
+        });
+    }
+
+    @Override
+    public Map<String, Map<String, String>> getPropertiesBySource() {
+        return withServiceTracker(killbillTracker, new APICallback<>(OSGIConfigProperties.class.getName()) {
+            @Override
+            public Map<String, Map<String, String>> executeWithService(final OSGIConfigProperties service) {
+                return service.getPropertiesBySource();
             }
         });
     }

--- a/platform-test/src/test/java/org/killbill/billing/beatrix/integration/osgi/util/SetupBundleWithAssertion.java
+++ b/platform-test/src/test/java/org/killbill/billing/beatrix/integration/osgi/util/SetupBundleWithAssertion.java
@@ -141,7 +141,9 @@ public class SetupBundleWithAssertion {
                     if (f.isDirectory()) {
                         deleteDirectory(f, true);
                     }
-                    Assert.assertTrue(f.delete(), "Unable to delete file " + f.getAbsolutePath());
+
+                    final boolean deleted = f.delete();
+                    Assert.assertTrue(deleted || !f.exists(), "Unable to delete file " + f.getAbsolutePath());
                 }
             }
             if (deleteParent) {
@@ -177,6 +179,7 @@ public class SetupBundleWithAssertion {
                 return createPluginJavaConfig(resourceUrl.getPath());
             }
         }
+
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,31 +193,6 @@
                 <artifactId>killbill-platform-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.20.45</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>ssm</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- Use jcl-over-slf4j instead -->
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- Avoid pulling 2 different versions in the war -->
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.51</version>
+        <version>0.146.56</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
     <version>0.41.16-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,31 @@
                 <artifactId>killbill-platform-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.20.45</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- Use jcl-over-slf4j instead -->
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Avoid pulling 2 different versions in the war -->
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
*  Added `getPropertiesBySource()` contract to `OSGIConfigProperties` interface
* Added implementation in `DefaultKillbillConfigSource` and `OSGIConfigPropertiesService` to expose runtime resolved properties grouped by config source.
* Added unit test to validate grouped property retrieval.