### PR TITLE
add org.killbill.billing.invoice.template.formatters in default expor…

### DIFF
--- a/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
+++ b/osgi/src/main/java/org/killbill/billing/osgi/config/OSGIConfig.java
@@ -110,7 +110,8 @@ public interface OSGIConfig extends KillbillPlatformConfig {
              // Let the world know the System bundle exposes the requirement (&(osgi.wiring.package=org.osgi.service.deploymentadmin)(version>=1.1.0)(!(version>=2.0.0)))
              "org.osgi.service.deploymentadmin;version=1.1.0," +
              // Let the world know the System bundle exposes the requirement (&(osgi.wiring.package=org.osgi.service.event)(version>=1.2.0)(!(version>=2.0.0)))
-             "org.osgi.service.event;version=1.2.0")
+             "org.osgi.service.event;version=1.2.0,"+
+            "org.killbill.billing.invoice.template.formatters")
     @Description("Kill Bill API packages to export from the system bundle")
     public String getSystemBundleExportPackagesApi();
 

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -28,5 +28,5 @@
     <artifactId>killbill-platform-api</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-api</name>
-    <dependencies />
+    <dependencies/>
 </project>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -278,8 +278,8 @@
                         <phase>initialize</phase>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar" />
-                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar" />
+                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar"/>
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Work for https://github.com/killbill/killbill-aviate-plugin/issues/268 - Add `org.killbill.billing.invoice.template.formatters` in the default exported packages. See https://github.com/killbill/killbill-aviate-plugin/pull/439#issuecomment-2971727663