### PR TITLE
#126 - add initialDelay to SSE scheduler to give server's handshake processing time

### DIFF
--- a/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/LogsSseHandler.java
+++ b/osgi-bundles/bundles/logger/src/main/java/org/killbill/billing/osgi/bundles/logger/LogsSseHandler.java
@@ -34,6 +34,9 @@ import org.killbill.commons.concurrent.Executors;
 
 public class LogsSseHandler implements Sse.Handler, Closeable {
 
+    private static final long INITIAL_DELAY_MS = 200;
+    private static final long PERIOD_MS = 1000;
+
     private final LogEntriesManager logEntriesManager;
     private final ScheduledExecutorService scheduledExecutorService;
 
@@ -54,7 +57,7 @@ public class LogsSseHandler implements Sse.Handler, Closeable {
         final UUID cacheId = UUID.fromString(sse.id());
         logEntriesManager.subscribe(cacheId, lastEventId);
 
-        final AtomicReference<UUID> lastLogId = new AtomicReference<UUID>();
+        final AtomicReference<UUID> lastLogId = new AtomicReference<>();
         final ScheduledFuture<?> future = scheduledExecutorService.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
@@ -71,7 +74,7 @@ public class LogsSseHandler implements Sse.Handler, Closeable {
                     }
                 }
             }
-        }, 0, 1, TimeUnit.SECONDS);
+        }, INITIAL_DELAY_MS, PERIOD_MS, TimeUnit.MILLISECONDS);
 
         sse.onClose(new Throwing.Runnable() {
             @Override


### PR DESCRIPTION
Original ticket : #126 . This PR also follow-up for this PR in Kill Bill repository : https://github.com/killbill/killbill/pull/2169

`LogsSseHandler` scheduled its drain loop with `initialDelay=0`, so the background thread could publish events while the servlet container was still completing the SSE handshake. In that window the channel remains in its blocking phase (asyncStarted could be `true`, but the response isn’t committed yet), and the container throw exception (IllegalStateException: api=BLOCKED in Jetty) when we write.

Video below shows what exactly happened:
1. 00.00 : Start server and initialize 2 `curl` calls to SSE endpoint
2. 00.42 : Show log for second SSE request with `jettyState=HANDLING .... responseCommitted=false` meaning the server still processing the handshake/request, and response not committed yet.

[platform-126-SSE-without-initial-delay.webm](https://github.com/user-attachments/assets/a47fa174-54c2-4698-82ae-47410f854769)

_To be continued in comment ...._
