### PR TITLE
fix sortpom problem

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-base</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-base</artifactId>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-lifecycle</artifactId>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-lifecycle</artifactId>

--- a/osgi-api/pom.xml
+++ b/osgi-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-api</artifactId>

--- a/osgi-api/pom.xml
+++ b/osgi-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-api</artifactId>

--- a/osgi-bundles/bundles/eureka/pom.xml
+++ b/osgi-bundles/bundles/eureka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-eureka</artifactId>

--- a/osgi-bundles/bundles/eureka/pom.xml
+++ b/osgi-bundles/bundles/eureka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-eureka</artifactId>

--- a/osgi-bundles/bundles/graphite/pom.xml
+++ b/osgi-bundles/bundles/graphite/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-graphite</artifactId>

--- a/osgi-bundles/bundles/graphite/pom.xml
+++ b/osgi-bundles/bundles/graphite/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-graphite</artifactId>

--- a/osgi-bundles/bundles/influxdb/pom.xml
+++ b/osgi-bundles/bundles/influxdb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-influxdb</artifactId>

--- a/osgi-bundles/bundles/influxdb/pom.xml
+++ b/osgi-bundles/bundles/influxdb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-influxdb</artifactId>

--- a/osgi-bundles/bundles/kpm/pom.xml
+++ b/osgi-bundles/bundles/kpm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-kpm</artifactId>

--- a/osgi-bundles/bundles/kpm/pom.xml
+++ b/osgi-bundles/bundles/kpm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-kpm</artifactId>

--- a/osgi-bundles/bundles/logger/pom.xml
+++ b/osgi-bundles/bundles/logger/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-logger</artifactId>

--- a/osgi-bundles/bundles/logger/pom.xml
+++ b/osgi-bundles/bundles/logger/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-logger</artifactId>

--- a/osgi-bundles/bundles/metrics/pom.xml
+++ b/osgi-bundles/bundles/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-metrics</artifactId>

--- a/osgi-bundles/bundles/metrics/pom.xml
+++ b/osgi-bundles/bundles/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-metrics</artifactId>

--- a/osgi-bundles/bundles/pom.xml
+++ b/osgi-bundles/bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles</artifactId>

--- a/osgi-bundles/bundles/pom.xml
+++ b/osgi-bundles/bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles</artifactId>

--- a/osgi-bundles/bundles/prometheus/pom.xml
+++ b/osgi-bundles/bundles/prometheus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-prometheus</artifactId>

--- a/osgi-bundles/bundles/prometheus/pom.xml
+++ b/osgi-bundles/bundles/prometheus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-prometheus</artifactId>

--- a/osgi-bundles/defaultbundles/pom.xml
+++ b/osgi-bundles/defaultbundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-defaultbundles</artifactId>

--- a/osgi-bundles/defaultbundles/pom.xml
+++ b/osgi-bundles/defaultbundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-defaultbundles</artifactId>

--- a/osgi-bundles/libs/killbill/pom.xml
+++ b/osgi-bundles/libs/killbill/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-lib-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-lib-killbill</artifactId>

--- a/osgi-bundles/libs/killbill/pom.xml
+++ b/osgi-bundles/libs/killbill/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-lib-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-lib-killbill</artifactId>

--- a/osgi-bundles/libs/pom.xml
+++ b/osgi-bundles/libs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-lib-bundles</artifactId>

--- a/osgi-bundles/libs/pom.xml
+++ b/osgi-bundles/libs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-lib-bundles</artifactId>

--- a/osgi-bundles/libs/slf4j-osgi/pom.xml
+++ b/osgi-bundles/libs/slf4j-osgi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-lib-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-lib-slf4j-osgi</artifactId>

--- a/osgi-bundles/libs/slf4j-osgi/pom.xml
+++ b/osgi-bundles/libs/slf4j-osgi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-lib-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-lib-slf4j-osgi</artifactId>

--- a/osgi-bundles/pom.xml
+++ b/osgi-bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-all-bundles</artifactId>

--- a/osgi-bundles/pom.xml
+++ b/osgi-bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-all-bundles</artifactId>

--- a/osgi-bundles/tests/beatrix/pom.xml
+++ b/osgi-bundles/tests/beatrix/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-test-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-test-beatrix</artifactId>

--- a/osgi-bundles/tests/beatrix/pom.xml
+++ b/osgi-bundles/tests/beatrix/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-test-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-test-beatrix</artifactId>

--- a/osgi-bundles/tests/payment/pom.xml
+++ b/osgi-bundles/tests/payment/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-test-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-test-payment</artifactId>

--- a/osgi-bundles/tests/payment/pom.xml
+++ b/osgi-bundles/tests/payment/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-test-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-bundles-test-payment</artifactId>

--- a/osgi-bundles/tests/pom.xml
+++ b/osgi-bundles/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-test-bundles</artifactId>

--- a/osgi-bundles/tests/pom.xml
+++ b/osgi-bundles/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform-osgi-all-bundles</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi-test-bundles</artifactId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi</artifactId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-osgi</artifactId>

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-api</artifactId>

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -28,5 +28,5 @@
     <artifactId>killbill-platform-api</artifactId>
     <packaging>jar</packaging>
     <name>killbill-platform-api</name>
-    <dependencies/>
+    <dependencies />
 </project>

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-api</artifactId>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-test</artifactId>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -278,8 +278,8 @@
                         <phase>initialize</phase>
                         <configuration>
                             <tasks>
-                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar"/>
-                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar"/>
+                                <copy file="${basedir}/../osgi-bundles/tests/beatrix/target/killbill-platform-osgi-bundles-test-beatrix-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-beatrix-jar-with-dependencies.jar" />
+                                <copy file="${basedir}/../osgi-bundles/tests/payment/target/killbill-platform-osgi-bundles-test-payment-${project.version}.jar" tofile="${basedir}/src/test/resources/killbill-osgi-bundles-test-payment-jar-with-dependencies.jar" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/platform-test/pom.xml
+++ b/platform-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.147.4</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
-    <version>0.42.0</version>
+    <version>0.42.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill-platform</name>
     <description>Platform to build billing and payment infrastructures</description>
@@ -45,7 +45,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-platform.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-platform.git</developerConnection>
-        <tag>killbill-platform-0.42.0</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill-platform/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.147.4</version>
     </parent>
     <artifactId>killbill-platform</artifactId>
-    <version>0.42.0-SNAPSHOT</version>
+    <version>0.42.0</version>
     <packaging>pom</packaging>
     <name>killbill-platform</name>
     <description>Platform to build billing and payment infrastructures</description>
@@ -45,7 +45,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill-platform.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill-platform.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-platform-0.42.0</tag>
         <url>http://github.com/killbill/killbill-platform/tree/master</url>
     </scm>
     <issueManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0</version>
+        <version>0.42.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-server</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-platform</artifactId>
-        <version>0.42.0-SNAPSHOT</version>
+        <version>0.42.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-platform-server</artifactId>


### PR DESCRIPTION
Fix problem like this when doing release: https://github.com/killbill/killbill-platform/actions/runs/27788852096 . 

This is need to be merged to master because [release action](https://github.com/killbill/killbill-platform/actions/runs/27789591772) performed from this branch (while testing and checking whether maven sortpom problem fixed or not), and thus, commit below happened in this branch:
- a56f406f6f7bc63ea3395c5c123564c4a7196cc6
- 80ee6a7d5931887f300e9cc63ea438ede5adbc52