### PR TITLE
#199 - remove all `oss.sonatype.org` references in code

### DIFF
--- a/osgi-bundles/bundles/kpm/CONFIGURATION.md
+++ b/osgi-bundles/bundles/kpm/CONFIGURATION.md
@@ -20,10 +20,8 @@ org.killbill.billing.plugin.kpm.connectTimeoutSec=60
 # 1. Backward compatibility with older configuration
 # 2. This is a "fallback" for pluginsInstall.coordinate configuration if "url/authMethod/authUsername/authPassword/authToken" not set.
 # 3. This is a required configuration to get Kill Bill version (See more AvailablePluginsComponentsFactory.createVersionsProvider() )
-# In codebase, if *.kpm.nexusUrl value not set, or contains "oss.sonatype.org", the final construct of URL would be 
-# ${*.kpm.nexusUrl} + "/content/repositories" + ${*.kpm.nexusRepository}. 
-org.killbill.billing.plugin.kpm.nexusUrl=https://oss.sonatype.org
-org.killbill.billing.plugin.kpm.nexusRepository=/releases
+org.killbill.billing.plugin.kpm.nexusUrl=https://repo1.maven.org
+org.killbill.billing.plugin.kpm.nexusRepository=/maven2
 
 # How Authentication header will construct. If none, then KPMPlugin will not send "Authorization" header when download 
 # any files. If BASIC, then *.kpm.nexusAuthToken value will be ignored and will use username/password values). 
@@ -74,7 +72,7 @@ org.killbill.billing.plugin.kpm.pluginsDirectory.authToken=VALID_TOKEN
 # pluginManager.install(pluginKey, kbVersion, groupId, artifactId, pluginVersion, forceDownload)
 # called.
 org.killbill.billing.plugin.kpm.pluginInstall.coordinate.verifySHA1=false
-org.killbill.billing.plugin.kpm.pluginInstall.coordinate.url=https://oss.sonatype.org/content/repositories/releases
+org.killbill.billing.plugin.kpm.pluginInstall.coordinate.url=https://repo1.maven.org/maven2
 org.killbill.billing.plugin.kpm.pluginInstall.coordinate.authMethod=NONE|BASIC|TOKEN
 org.killbill.billing.plugin.kpm.pluginInstall.coordinate.authUsername=VALID_USERNAME|KPM_NEXUS_AUTH_USERNAME
 org.killbill.billing.plugin.kpm.pluginInstall.coordinate.authPassword=VALID_PASSWORD|KPM_NEXUS_AUTH_PASSWORD

--- a/osgi-bundles/bundles/kpm/spotbugs-exclude.xml
+++ b/osgi-bundles/bundles/kpm/spotbugs-exclude.xml
@@ -45,4 +45,17 @@
         <Method name="uninstall" params="java.lang.String, java.lang.String" />
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
     </Match>
+
+    <Match>
+        <Class name="org.killbill.billing.osgi.bundles.kpm.impl.CoordinateBasedPluginDownloader" />
+        <Method name="&lt;init&gt;"
+                params="
+                    org.killbill.billing.osgi.bundles.kpm.KPMClient,
+                    org.killbill.billing.osgi.bundles.kpm.impl.ArtifactAndVersionFinder,
+                    org.killbill.billing.osgi.bundles.kpm.UriResolver,
+                    boolean,
+                    boolean"
+        />
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 </FindBugsFilter>

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KpmProperties.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/KpmProperties.java
@@ -63,17 +63,17 @@ public final class KpmProperties {
     }
 
     /**
-     * @return get {@code org.killbill.billing.plugin.kpm.nexusUrl} property, or {@code https://oss.sonatype.org/} if not set.
+     * @return get {@code org.killbill.billing.plugin.kpm.nexusUrl} property, or {@code https://repo1.maven.org} if not set.
      */
     public String getNexusUrl() {
-        return Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusUrl"), "https://oss.sonatype.org");
+        return Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusUrl"), "https://repo1.maven.org");
     }
 
     /**
-     * @return get {@code org.killbill.billing.plugin.kpm.nexusRepository} property, or {@code releases} if not set.
+     * @return get {@code org.killbill.billing.plugin.kpm.nexusRepository} property, or {@code maven2} if not set.
      */
     public String getNexusRepository() {
-        return Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusRepository"), "/releases");
+        return Objects.requireNonNullElse(properties.getProperty(PROPERTY_PREFIX + "nexusRepository"), "/maven2");
     }
 
     /**

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/CoordinateBasedPluginDownloader.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/CoordinateBasedPluginDownloader.java
@@ -42,7 +42,7 @@ class CoordinateBasedPluginDownloader {
 
     private static final String KILLBILL_GROUP_ID = "org.kill-bill.billing.plugin.java";
 
-    private static final String SONATYPE_RELEASE_URL = "https://oss.sonatype.org/content/repositories/releases/";
+    private static final String PUBLIC_RELEASE_URL = "https://repo1.maven.org/maven2/";
 
     private final KPMClient httpClient;
     private final Sha1Checker sha1Checker;
@@ -60,6 +60,10 @@ class CoordinateBasedPluginDownloader {
         this.uriResolver = uriResolver;
         this.sha1Checker = new Sha1Checker(httpClient, shouldVerify);
         this.shouldTryPublicRepository = shouldTryPublicRepository;
+
+        if (this.uriResolver.getBaseUri().contains("oss.sonatype.org")) {
+            throw new IllegalStateException(String.format("Unsupported repository URL '%s': oss.sonatype.org is no longer supported.", this.uriResolver.getBaseUri()));
+        }
     }
 
     DownloadResult download(final String pluginKey,
@@ -150,14 +154,12 @@ class CoordinateBasedPluginDownloader {
     private Path downloadFromPublicKillbill(final String pluginKey, final String groupId, final String artifactId, final String version) {
         // If downloadFromNexusUri() already from sonatype/maven, then do not repeat.
         // If shouldTryPublicRepository = false, then do not download.
-        if (uriResolver.getBaseUri().startsWith("https://oss.sonatype.org") ||
-            uriResolver.getBaseUri().startsWith("https://repo1.maven.org/maven2") ||
-            !this.shouldTryPublicRepository) {
+        if (uriResolver.getBaseUri().startsWith("https://repo1.maven.org/maven2") || !this.shouldTryPublicRepository) {
             return null;
         }
 
-        final String jarUrl =  SONATYPE_RELEASE_URL + coordinateToUri(groupId, artifactId, version, ".jar");
-        final String sha1Url = SONATYPE_RELEASE_URL + coordinateToUri(groupId, artifactId, version, ".jar.sha1");
+        final String jarUrl = PUBLIC_RELEASE_URL + coordinateToUri(groupId, artifactId, version, ".jar");
+        final String sha1Url = PUBLIC_RELEASE_URL + coordinateToUri(groupId, artifactId, version, ".jar.sha1");
         logger.debug("#downloadFromPublicKillbill() . jarUrl: {}, sha1Url: {}", jarUrl, sha1Url);
 
         return doDownloadValidateAndVerify(pluginKey, version, jarUrl, sha1Url);

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultNexusMetadataFiles.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/DefaultNexusMetadataFiles.java
@@ -48,7 +48,7 @@ class DefaultNexusMetadataFiles implements NexusMetadataFiles {
         this.mavenMetadataXmlUrl = mavenMetadataXmlUrl;
         this.killbillVersionOrLatest = killbillVersionOrLatest;
 
-        logger.debug("Will get killbill info from sonatype repository with basePath:{}, and killbillVersion:{}", uriResolver.getBaseUri(), killbillVersionOrLatest);
+        logger.debug("Will get Kill Bill repository with basePath:{}, and killbillVersion:{}", uriResolver.getBaseUri(), killbillVersionOrLatest);
     }
 
     @Override
@@ -96,11 +96,13 @@ class DefaultNexusMetadataFiles implements NexusMetadataFiles {
 
     @VisibleForTesting
     Path getMavenMetadataXml() {
+        if (mavenMetadataXmlUrl.contains("oss.sonatype.org")) {
+            throw new IllegalStateException(String.format("Unsupported repository URL '%s': oss.sonatype.org is no longer supported.", mavenMetadataXmlUrl));
+        }
         final String[] fileNameAndExt = {"maven-metadata", ".xml"};
         // Do not send any header if it is public repository
         if (uriResolver.getAuthMethod() == AuthenticationMethod.NONE ||
-            mavenMetadataXmlUrl.contains("repo1.maven.org") ||
-            mavenMetadataXmlUrl.contains("oss.sonatype.org")) {
+            mavenMetadataXmlUrl.contains("repo1.maven.org")) {
             return httpClient.downloadToTempOS(mavenMetadataXmlUrl, fileNameAndExt);
         } else {
             return httpClient.downloadToTempOS(mavenMetadataXmlUrl, uriResolver.getHeaders(), fileNameAndExt);

--- a/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/UrlResolverFactory.java
+++ b/osgi-bundles/bundles/kpm/src/main/java/org/killbill/billing/osgi/bundles/kpm/impl/UrlResolverFactory.java
@@ -31,18 +31,6 @@ public class UrlResolverFactory {
         this.kpmProperties = kpmProperties;
     }
 
-    // This is for backward compatibility: by default, nexusUrl is "https://oss.sonatype.org/" and
-    // nexusRepository is "releases". But if we just simply concat them like 'https://oss.sonatype.org/releases',
-    // this is not valid sonatype URL.
-    // However, this is only applied to 'NONE' authentication method, because for other authentication methods, it is
-    // very likely that users have another url other than 'https://oss.sonatype.org/' and 'releases'. We can't guess and
-    // add something like "/content/repositories" at this point.
-    private String getValidUrlIfSonatype(final String url) {
-        return url.contains("oss.sonatype.org") ?
-               kpmProperties.getNexusUrl().concat("/content/repositories").concat(kpmProperties.getNexusRepository()) :
-               url;
-    }
-
     /**
      * Will create {@link UriResolver} instance for configuration:
      * <ul>
@@ -54,19 +42,18 @@ public class UrlResolverFactory {
      */
     public UriResolver getVersionsProviderUrlResolver() {
         final AuthenticationMethod authMethod = AuthenticationMethod.valueOf(kpmProperties.getNexusAuthMethod().toUpperCase());
+        final String baseUrl = kpmProperties.getNexusUrl() + kpmProperties.getNexusRepository();
         switch (authMethod) {
             case NONE:
-                String baseUrl = getValidUrlIfSonatype(kpmProperties.getNexusUrl() + kpmProperties.getNexusRepository());
+
                 return new NoneUriResolver(baseUrl);
 
             case BASIC:
-                baseUrl = kpmProperties.getNexusUrl().concat(kpmProperties.getNexusRepository());
                 final String username = kpmProperties.getNexusAuthUsername();
                 final String password = kpmProperties.getNexusAuthPassword();
                 return new BasicUriResolver(baseUrl, username, password);
 
             case TOKEN:
-                baseUrl = kpmProperties.getNexusUrl().concat(kpmProperties.getNexusRepository());
                 return new TokenUriResolver(baseUrl, kpmProperties.getNexusAuthToken());
 
             default: throw new IllegalStateException("Unknown authentication method: " + kpmProperties.getNexusAuthMethod());
@@ -83,7 +70,7 @@ public class UrlResolverFactory {
         final AuthenticationMethod authMethod = AuthenticationMethod.valueOf(pluginsDirectory.getAuthMethod());
         switch (authMethod) {
             case NONE:
-                return new NoneUriResolver(getValidUrlIfSonatype(pluginsDirectory.getUrl()));
+                return new NoneUriResolver(pluginsDirectory.getUrl());
 
             case BASIC:
                 return new BasicUriResolver(pluginsDirectory.getUrl(), pluginsDirectory.getAuthUsername(), pluginsDirectory.getAuthPassword());
@@ -106,7 +93,7 @@ public class UrlResolverFactory {
         final AuthenticationMethod authMethod = AuthenticationMethod.valueOf(pluginsInstallCoordinate.getAuthMethod());
         switch (authMethod) {
             case NONE:
-                return new NoneUriResolver(getValidUrlIfSonatype(pluginsInstallCoordinate.getUrl()));
+                return new NoneUriResolver(pluginsInstallCoordinate.getUrl());
 
             case BASIC:
                 return new BasicUriResolver(pluginsInstallCoordinate.getUrl(),

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultNexusMetadataFiles.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultNexusMetadataFiles.java
@@ -61,7 +61,7 @@ public class TestDefaultNexusMetadataFiles {
     }
 
     private void testGetKillbillPomXml(final String kbVersion) throws Exception {
-        final UriResolver uriResolver = new NoneUriResolver("https://oss.sonatype.org/content/repositories/releases");
+        final UriResolver uriResolver = new NoneUriResolver("https://repo1.maven.org/maven2");
 
         nexusMetadataFiles = spyNexusMetadataFiles(kpmClient, uriResolver, MAVEN_METADATA_XML, kbVersion);
         final Path killbillPom = nexusMetadataFiles.getKillbillPomXml();
@@ -89,7 +89,7 @@ public class TestDefaultNexusMetadataFiles {
     }
 
     private void testGetOssParentPomXml(final String kbVersion) throws Exception {
-        final UriResolver uriResolver = new NoneUriResolver("https://oss.sonatype.org/content/repositories/releases");
+        final UriResolver uriResolver = new NoneUriResolver("https://repo1.maven.org/maven2");
 
         nexusMetadataFiles = spyNexusMetadataFiles(kpmClient, uriResolver, MAVEN_METADATA_XML, kbVersion);
         final Path ossParentPomXml = nexusMetadataFiles.getOssParentPomXml();

--- a/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginManager.java
+++ b/osgi-bundles/bundles/kpm/src/test/java/org/killbill/billing/osgi/bundles/kpm/impl/TestDefaultPluginManager.java
@@ -23,6 +23,7 @@ import org.killbill.billing.osgi.bundles.kpm.KPMPluginException;
 import org.killbill.billing.osgi.bundles.kpm.KpmProperties;
 import org.killbill.billing.osgi.bundles.kpm.PluginIdentifiersDAO;
 import org.killbill.billing.osgi.bundles.kpm.PluginManager.GetAvailablePluginsModel;
+import org.killbill.billing.osgi.bundles.kpm.TestUtils;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 import org.killbill.billing.util.nodes.NodeInfo;
@@ -47,7 +48,7 @@ public class TestDefaultPluginManager {
         final OSGIKillbillAPI osgiKillbillAPI = Mockito.mock(OSGIKillbillAPI.class);
         Mockito.when(osgiKillbillAPI.getKillbillNodesApi()).thenReturn(nodesApi);
 
-        final Properties properties = new Properties();
+        final Properties properties = TestUtils.getTestProperties();
         properties.setProperty("org.killbill.billing.plugin.kpm.availablePlugins.cache.enabled", "true");
         final KpmProperties kpmProperties = new KpmProperties(properties);
 


### PR DESCRIPTION
See https://github.com/killbill/killbill-platform/issues/199 . Commit are self-explanatory. 

One commit back-ported from `master` in test area (we can create new commit, it affect nothing other than fixing the test): f2ea0c8c0d3aff2ae8ab6671a728ee06f7bf3670